### PR TITLE
Improve CLI input validation

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -27,6 +27,24 @@ def show_menu():
     print("5. Lagerplatz hinzufügen")
     print("0. Beenden")
 
+
+def _get_float(prompt: str) -> float:
+    """Prompt the user for a float until valid input is given."""
+    while True:
+        try:
+            return float(input(prompt))
+        except ValueError:
+            print("Bitte eine gültige Zahl eingeben.")
+
+
+def _get_int(prompt: str) -> int:
+    """Prompt the user for an integer until valid input is given."""
+    while True:
+        try:
+            return int(input(prompt))
+        except ValueError:
+            print("Bitte eine gültige Ganzzahl eingeben.")
+
 def run():
     initialize_if_needed()
     while True:
@@ -38,7 +56,7 @@ def run():
             set_code = input("Set-Code (z. B. M21): ")
             language = input("Sprache: ")
             condition = input("Zustand (z. B. Near Mint): ")
-            price = float(input("Preis (€): "))
+            price = _get_float("Preis (€): ")
             storage_code = input("Lagercode (z. B. O01-S01-H01): ")
             cardmarket_id = input("Cardmarket-ID (optional): ")
             add_card(name, set_code, language, condition, price, storage_code, cardmarket_id)
@@ -47,15 +65,16 @@ def run():
             list_all_cards()
 
         elif choice == "3":
-            card_id = int(input("Karten-ID zum Bearbeiten: "))
+            card_id = _get_int("Karten-ID zum Bearbeiten: ")
             field = input("Welches Feld bearbeiten? (z. B. price): ")
-            value = input("Neuer Wert: ")
             if field == "price":
-                value = float(value)
+                value = _get_float("Neuer Wert: ")
+            else:
+                value = input("Neuer Wert: ")
             update_card(card_id, **{field: value})
 
         elif choice == "4":
-            card_id = int(input("Karten-ID zum Löschen: "))
+            card_id = _get_int("Karten-ID zum Löschen: ")
             delete_card(card_id)
 
         elif choice == "5":


### PR DESCRIPTION
## Summary
- protect numeric inputs for price and card IDs in CLI
- prompt again on invalid input instead of exiting

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m TCGInventory.setup_db`

------
https://chatgpt.com/codex/tasks/task_e_684ae816b5dc832baa924aced9c09549