### PR TITLE
Implement card scanning and Cardmarket placeholders

### DIFF
--- a/card_scanner.py
+++ b/card_scanner.py
@@ -1,0 +1,48 @@
+import cv2
+from pyzbar.pyzbar import decode
+from queue import Queue
+from typing import Optional, Dict
+import requests
+
+SCRYFALL_API_URL = "https://api.scryfall.com/cards/"
+
+# Queue für gescannte Karten
+SCANNER_QUEUE: Queue[Dict] = Queue()
+
+def scan_image(path: str) -> Optional[str]:
+    """Scan an image file for barcodes and return the first result as string."""
+    image = cv2.imread(path)
+    if image is None:
+        print(f"❌ Bild {path} konnte nicht geladen werden.")
+        return None
+    codes = decode(image)
+    if not codes:
+        print("❌ Kein Barcode gefunden.")
+        return None
+    return codes[0].data.decode("utf-8")
+
+def fetch_card_info(card_id: str) -> Optional[Dict]:
+    """Retrieve card details from Scryfall."""
+    try:
+        resp = requests.get(f"{SCRYFALL_API_URL}{card_id}")
+        resp.raise_for_status()
+    except requests.RequestException as exc:
+        print(f"❌ Fehler beim Abrufen der Kartendaten: {exc}")
+        return None
+    data = resp.json()
+    return {
+        "name": data.get("name"),
+        "set_code": data.get("set"),
+        "language": data.get("lang"),
+        "cardmarket_id": data.get("id"),
+    }
+
+def scan_and_queue(image_path: str) -> None:
+    """Scan a card from an image and put its info into the queue."""
+    card_id = scan_image(image_path)
+    if not card_id:
+        return
+    info = fetch_card_info(card_id)
+    if info:
+        SCANNER_QUEUE.put(info)
+        print(f"📸 Karte '{info['name']}' zur Queue hinzugefügt.")

--- a/cardmarket_api.py
+++ b/cardmarket_api.py
@@ -1,0 +1,9 @@
+"""Simple Cardmarket API placeholder."""
+from typing import Dict
+
+
+def upload_card(card: Dict) -> None:
+    """Pretend to upload card data to Cardmarket."""
+    # Diese Funktion sollte echte Cardmarket-API-Aufrufe enthalten.
+    print(f"🔗 Upload zu Cardmarket: {card['name']} ({card.get('set_code')})")
+

--- a/cli.py
+++ b/cli.py
@@ -9,6 +9,8 @@ from TCGInventory.lager_manager import (
 )
 from TCGInventory.setup_db import initialize_database
 from TCGInventory import DB_FILE
+from TCGInventory.card_scanner import scan_and_queue, SCANNER_QUEUE
+from TCGInventory.cardmarket_api import upload_card
 
 
 
@@ -25,6 +27,8 @@ def show_menu():
     print("3. Karte bearbeiten")
     print("4. Karte löschen")
     print("5. Lagerplatz hinzufügen")
+    print("6. Karte scannen (Bild)")
+    print("7. Karte aus Queue hochladen")
     print("0. Beenden")
 
 
@@ -80,6 +84,17 @@ def run():
         elif choice == "5":
             code = input("Neuer Lagerplatz-Code (z. B. O02-S04-H09): ")
             add_storage_slot(code)
+
+        elif choice == "6":
+            path = input("Pfad zum Kartenbild: ")
+            scan_and_queue(path)
+
+        elif choice == "7":
+            if SCANNER_QUEUE.empty():
+                print("⚠️ Keine Karten in der Queue.")
+            else:
+                card = SCANNER_QUEUE.get()
+                upload_card(card)
 
         elif choice == "0":
             print("👋 Programm beendet.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,9 @@
 # Application dependencies
 # Only tabulate is needed for pretty-printing tables.
 tabulate
+
+# Scanner and API dependencies
+opencv-python
+pyzbar
+requests
+pillow


### PR DESCRIPTION
## Summary
- add a camera barcode scanner helper that fetches card data from Scryfall
- add a placeholder module for uploading cards to Cardmarket
- extend CLI with options for scanning cards and uploading from a queue
- include new dependencies for scanning and HTTP requests

## Testing
- `python -m py_compile card_scanner.py cardmarket_api.py cli.py lager_manager.py setup_db.py __init__.py test.py`
- `python -m TCGInventory.test` *(fails: `no such table: storage_slots`)*

------
https://chatgpt.com/codex/tasks/task_e_684aeb2dbab0832bbf2b1939153f50b7