### PR TITLE
Fix DB constant usage

### DIFF
--- a/lager_manager.py
+++ b/lager_manager.py
@@ -2,7 +2,7 @@ import sqlite3
 from datetime import datetime
 from tabulate import tabulate
 
-DB_FILE = "mtg_lager.db"
+from . import DB_FILE
 
 # Valid columns in the ``cards`` table that can be updated via ``update_card``
 ALLOWED_FIELDS = {

--- a/setup_db.py
+++ b/setup_db.py
@@ -1,6 +1,6 @@
 import sqlite3
 
-DB_FILE = "mtg_lager.db"
+from . import DB_FILE
 
 
 def initialize_database() -> None:


### PR DESCRIPTION
## Summary
- remove duplicated `DB_FILE` constants
- import package constant in `lager_manager` and `setup_db`

## Testing
- `python -m py_compile TCGInventory/*.py`
- `python -m TCGInventory.setup_db`
- `python -m TCGInventory.test`


------
https://chatgpt.com/codex/tasks/task_e_684aedf1f4e8832b9f5ef5afd4d84f87