### PR TITLE
Remove Cardmarket code and add binder slots

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,16 +11,7 @@ Install the required dependencies with ``pip``:
 pip install -r requirements.txt
 ```
 
-The Cardmarket integration requires additional environment variables for OAuth1
-authentication:
-
-```
-MKM_APP_TOKEN=<your app token>
-MKM_APP_SECRET=<your app secret>
-MKM_TOKEN=<your access token>
-MKM_TOKEN_SECRET=<your access token secret>
-FLASK_SECRET_KEY=<secret for the web interface>
-```
+For the optional web interface set ``FLASK_SECRET_KEY`` in your environment.
 
 ## Usage
 
@@ -36,8 +27,12 @@ Run the CLI via the module path so Python can resolve the ``TCGInventory`` packa
 python -m TCGInventory.cli
 ```
 
-Within the CLI you can now update article prices on Cardmarket and fetch your
-current sales.  When sales are fetched, a PDF summary can be generated.
+The CLI automatically manages storage slots.  Create binders for each set using
+option ``Ordner anlegen``.  Specify the set code and the number of pages; each
+page provides nine slots.  When you add a card without specifying a storage
+code, the next free slot in the corresponding binder will be used.
+
+
 
 Example functions can also be called programmatically, e.g.:
 
@@ -52,8 +47,7 @@ data elsewhere.
 ## Web Interface
 
 In addition to the CLI a small Flask based web application is available.  It
-provides the same basic functionality like viewing, adding and editing cards as
-well as interacting with Cardmarket.
+provides basic functionality like viewing, adding and editing cards.
 
 Start the local server with:
 

--- a/cli.py
+++ b/cli.py
@@ -3,16 +3,13 @@ import os
 from TCGInventory.lager_manager import (
     add_card,
     add_storage_slot,
+    create_binder,
     update_card,
     delete_card,
     list_all_cards,
 )
 from TCGInventory.setup_db import initialize_database
 from TCGInventory import DB_FILE
-from TCGInventory.card_scanner import scan_and_queue, SCANNER_QUEUE
-from TCGInventory.cardmarket_api import upload_card, CardmarketClient
-
-MKM_CLIENT = CardmarketClient.from_env()
 
 
 
@@ -28,11 +25,7 @@ def show_menu():
     print("2. Alle Karten anzeigen")
     print("3. Karte bearbeiten")
     print("4. Karte löschen")
-    print("5. Lagerplatz hinzufügen")
-    print("6. Karte scannen (Bild)")
-    print("7. Karte aus Queue hochladen")
-    print("8. Preis auf Cardmarket aktualisieren")
-    print("9. Verkäufe abrufen und als PDF speichern")
+    print("5. Ordner anlegen")
     print("0. Beenden")
 
 
@@ -66,16 +59,12 @@ def run():
                 language = input("Sprache: ")
                 condition = input("Zustand (z. B. Near Mint): ")
                 price = _get_float("Preis (€): ")
-                storage_code = input("Lagercode (z. B. O01-S01-H01): ")
-                cardmarket_id = input("Cardmarket-ID (optional): ")
                 add_card(
                     name,
                     set_code,
                     language,
                     condition,
                     price,
-                    storage_code,
-                    cardmarket_id,
                 )
 
             elif choice == "2":
@@ -95,32 +84,9 @@ def run():
                 delete_card(card_id)
 
             elif choice == "5":
-                code = input("Neuer Lagerplatz-Code (z. B. O02-S04-H09): ")
-                add_storage_slot(code)
-
-            elif choice == "6":
-                path = input("Pfad zum Kartenbild: ")
-                scan_and_queue(path)
-
-            elif choice == "7":
-                if SCANNER_QUEUE.empty():
-                    print("⚠️ Keine Karten in der Queue.")
-                else:
-                    card = SCANNER_QUEUE.get()
-                    upload_card(card)
-
-            elif choice == "8":
-                article_id = _get_int("Cardmarket Artikel-ID: ")
-                new_price = _get_float("Neuer Preis (€): ")
-                MKM_CLIENT.update_price(article_id, new_price)
-
-            elif choice == "9":
-                sales = MKM_CLIENT.fetch_sales()
-                if not sales:
-                    print("Keine Verkäufe gefunden.")
-                else:
-                    path = input("PDF-Datei speichern unter: ")
-                    MKM_CLIENT.sales_to_pdf(sales, path)
+                set_code = input("Set-Code für den Ordner: ")
+                pages = _get_int("Anzahl Seiten: ")
+                create_binder(set_code, pages)
 
             elif choice == "0":
                 print("👋 Programm beendet.")

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,11 +4,7 @@
 <nav>
   <a href="{{ url_for('list_cards') }}">Cards</a> |
   <a href="{{ url_for('add_card_view') }}">Add Card</a> |
-  <a href="{{ url_for('add_storage_view') }}">Add Storage</a> |
-  <a href="{{ url_for('scan_view') }}">Scan Card</a> |
-  <a href="{{ url_for('queue_view') }}">Queue</a> |
-  <a href="{{ url_for('update_price_view') }}">Update Price</a> |
-  <a href="{{ url_for('fetch_sales') }}">Sales</a>
+  <a href="{{ url_for('add_storage_view') }}">Add Storage</a>
 </nav>
 <hr>
 {% with messages = get_flashed_messages() %}

--- a/templates/card_form.html
+++ b/templates/card_form.html
@@ -7,7 +7,7 @@
   Language: <input name="language" value="{{ card[3] if card else '' }}"><br>
   Condition: <input name="condition" value="{{ card[4] if card else '' }}"><br>
   Price: <input type="number" step="0.01" name="price" value="{{ card[5] if card else '' }}"><br>
-  Storage Code: <input name="storage_code" value="{{ card[6] if card else '' }}"><br>
+  Storage Code (optional): <input name="storage_code" value="{{ card[6] if card else '' }}"><br>
   Cardmarket ID: <input name="cardmarket_id" value="{{ card[7] if card else '' }}"><br>
   <input type="submit" value="Save">
 </form>

--- a/web.py
+++ b/web.py
@@ -1,18 +1,18 @@
 import os
 import sqlite3
-from queue import Queue
 from flask import Flask, render_template, request, redirect, url_for, flash
 
-from TCGInventory.lager_manager import add_card, update_card, delete_card, add_storage_slot
-from TCGInventory.card_scanner import scan_and_queue, SCANNER_QUEUE
-from TCGInventory.cardmarket_api import upload_card, CardmarketClient
+from TCGInventory.lager_manager import (
+    add_card,
+    update_card,
+    delete_card,
+    add_storage_slot,
+)
 from TCGInventory.setup_db import initialize_database
 from TCGInventory import DB_FILE
 
 app = Flask(__name__)
 app.secret_key = os.environ.get("FLASK_SECRET_KEY", "tcg-secret")
-
-MKM_CLIENT = CardmarketClient.from_env()
 
 
 def init_db() -> None:
@@ -59,7 +59,7 @@ def add_card_view():
             request.form.get("language", ""),
             request.form.get("condition", ""),
             float(request.form.get("price", 0) or 0),
-            request.form["storage_code"],
+            request.form.get("storage_code", ""),
             request.form.get("cardmarket_id", ""),
         )
         flash("Card added")
@@ -78,7 +78,7 @@ def edit_card_view(card_id: int):
             language=request.form.get("language", ""),
             condition=request.form.get("condition", ""),
             price=float(request.form.get("price", 0) or 0),
-            storage_code=request.form["storage_code"],
+            storage_code=request.form.get("storage_code", ""),
             cardmarket_id=request.form.get("cardmarket_id", ""),
         )
         flash("Card updated")
@@ -102,58 +102,6 @@ def add_storage_view():
     return render_template("storage_form.html")
 
 
-@app.route("/scan", methods=["GET", "POST"])
-def scan_view():
-    if request.method == "POST":
-        image = request.files.get("image")
-        if image:
-            os.makedirs("uploads", exist_ok=True)
-            path = os.path.join("uploads", image.filename)
-            image.save(path)
-            scan_and_queue(path)
-            flash("Image scanned")
-            return redirect(url_for("queue_view"))
-    return render_template("scan.html")
-
-
-@app.route("/queue")
-def queue_view():
-    items = list(SCANNER_QUEUE.queue)
-    return render_template("queue.html", queue=items)
-
-
-@app.route("/queue/upload/<int:index>")
-def upload_card_route(index: int):
-    items = list(SCANNER_QUEUE.queue)
-    if 0 <= index < len(items):
-        card = items[index]
-        upload_card(card)
-        new_q: Queue = Queue()
-        for i, item in enumerate(items):
-            if i != index:
-                new_q.put(item)
-        SCANNER_QUEUE.queue.clear()
-        while not new_q.empty():
-            SCANNER_QUEUE.put(new_q.get())
-        flash(f"Card '{card.get('name', '')}' uploaded")
-    return redirect(url_for("queue_view"))
-
-
-@app.route("/update_price", methods=["GET", "POST"])
-def update_price_view():
-    if request.method == "POST":
-        article_id = int(request.form.get("article_id", 0) or 0)
-        price = float(request.form.get("new_price", 0) or 0)
-        MKM_CLIENT.update_price(article_id, price)
-        flash("Price updated")
-        return redirect(url_for("index"))
-    return render_template("update_price.html")
-
-
-@app.route("/sales")
-def fetch_sales():
-    sales = MKM_CLIENT.fetch_sales()
-    return render_template("sales.html", sales=sales)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- drop Cardmarket and scanner features from CLI and web UI
- add binder management helpers and auto-assign storage slots
- simplify navigation templates
- document binder workflow in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852c1d58b1c832baf304b75286fb209