### PR TITLE
Improve folder handling and bulk import

### DIFF
--- a/card_scanner.py
+++ b/card_scanner.py
@@ -46,6 +46,25 @@ def fetch_card_info(card_id: str) -> Optional[CardInfo]:
         "cardmarket_id": data.get("id"),
     }
 
+
+def fetch_card_info_by_name(name: str) -> Optional[CardInfo]:
+    """Retrieve card details from Scryfall using the card name."""
+    try:
+        resp = requests.get(
+            f"https://api.scryfall.com/cards/named", params={"exact": name}, timeout=5
+        )
+        resp.raise_for_status()
+    except requests.RequestException as exc:
+        print(f"❌ Fehler beim Abrufen der Kartendaten: {exc}")
+        return None
+    data = resp.json()
+    return {
+        "name": data.get("name", name),
+        "set_code": data.get("set", ""),
+        "language": data.get("lang", ""),
+        "cardmarket_id": data.get("id", ""),
+    }
+
 def scan_and_queue(image_path: str) -> None:
     """Scan a card from an image and put its info into the queue."""
     card_id = scan_image(image_path)

--- a/templates/base.html
+++ b/templates/base.html
@@ -13,7 +13,7 @@
       <a class="btn btn-secondary me-2" href="{{ url_for('add_card_view') }}">Add Card</a>
       <a class="btn btn-secondary me-2" href="{{ url_for('bulk_add_view') }}">Bulk Add</a>
       <a class="btn btn-secondary me-2" href="{{ url_for('list_folders_view') }}">Folders</a>
-      <a class="btn btn-secondary" href="{{ url_for('add_storage_view') }}">Add Storage</a>
+      {# Storage management not required right now #}
     </nav>
     {% with messages = get_flashed_messages() %}
       {% if messages %}

--- a/templates/bulk_add.html
+++ b/templates/bulk_add.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block content %}
 <h2 class="mb-4">Bulk Add Cards</h2>
-<form method="post">
+<form method="post" enctype="multipart/form-data">
   <div class="mb-3">
     <label class="form-label">Folder</label>
     <select name="folder_id" class="form-select">
@@ -12,8 +12,12 @@
     </select>
   </div>
   <div class="mb-3">
-    <label class="form-label">Cards (name,set_code per line)</label>
+    <label class="form-label">Cards (one name per line)</label>
     <textarea name="cards" class="form-control" rows="6"></textarea>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">JSON File</label>
+    <input type="file" name="json_file" class="form-control">
   </div>
   <button type="submit" class="btn btn-primary">Add</button>
 </form>

--- a/templates/card_form.html
+++ b/templates/card_form.html
@@ -7,10 +7,6 @@
     <input class="form-control" name="name" value="{{ card[1] if card else '' }}" required>
   </div>
   <div class="mb-3">
-    <label class="form-label">Set Code</label>
-    <input class="form-control" name="set_code" value="{{ card[2] if card else '' }}" required>
-  </div>
-  <div class="mb-3">
     <label class="form-label">Language</label>
     <input class="form-control" name="language" value="{{ card[3] if card else '' }}">
   </div>
@@ -32,7 +28,7 @@
   </div>
   {% if folders is not none %}
   <div class="mb-3">
-    <label class="form-label">Folder</label>
+    <label class="form-label">Folder (Set)</label>
     <select name="folder_id" class="form-select">
       <option value="">-- none --</option>
       {% for f in folders %}

--- a/templates/folders.html
+++ b/templates/folders.html
@@ -1,11 +1,22 @@
 {% extends "base.html" %}
 {% block content %}
 <h2 class="mb-4">Folders</h2>
-<table class="table table-striped">
-<tr><th>ID</th><th>Name</th></tr>
 {% for f in folders %}
-<tr><td>{{ f[0] }}</td><td>{{ f[1] }}</td></tr>
+  <h4 class="mt-4">{{ f[1] }}</h4>
+  <table class="table table-sm table-striped">
+    <tr><th>ID</th><th>Name</th><th>Set</th><th>Storage</th></tr>
+    {% for c in folder_cards.get(f[0], []) %}
+    <tr>
+      <td>{{ c[0] }}</td>
+      <td>{{ c[1] }}</td>
+      <td>{{ c[2] }}</td>
+      <td>{{ c[3] }}</td>
+    </tr>
+    {% endfor %}
+    {% if not folder_cards.get(f[0], []) %}
+    <tr><td colspan="4" class="text-muted">No cards</td></tr>
+    {% endif %}
+  </table>
 {% endfor %}
-</table>
-<a href="{{ url_for('add_folder_view') }}" class="btn btn-primary">Add Folder</a>
+<a href="{{ url_for('add_folder_view') }}" class="btn btn-primary mt-3">Add Folder</a>
 {% endblock %}


### PR DESCRIPTION
## Summary
- remove the unused "Add Storage" nav link
- use folder name as set code when adding/editing cards
- show cards grouped by folder
- allow bulk import from plaintext or JSON and fetch card data via Scryfall
- add helper to fetch card info by name

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r TCGInventory/requirements.txt`
- `PYTHONPATH=. python TCGInventory/test.py`

------
https://chatgpt.com/codex/tasks/task_e_6852cbc30634832bab3749219225988c