### PR TITLE
Add Scryfall autocomplete for card names

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,7 @@ not exist.  Open ``http://localhost:5000`` in your browser to use the
 interface.
 
 For a detailed walkthrough of the available pages and forms, see [docs/WEB_INTERFACE.md](docs/WEB_INTERFACE.md).
+
+## Autocomplete
+
+When adding a card through the web interface the **Name** field now shows suggestions provided by the Scryfall API. Start typing to get a dropdown list of matching card names.

--- a/card_scanner.py
+++ b/card_scanner.py
@@ -65,6 +65,22 @@ def fetch_card_info_by_name(name: str) -> Optional[CardInfo]:
         "cardmarket_id": data.get("id", ""),
     }
 
+
+def autocomplete_names(query: str) -> list[str]:
+    """Return card name suggestions from Scryfall for the given query."""
+    try:
+        resp = requests.get(
+            "https://api.scryfall.com/cards/autocomplete",
+            params={"q": query},
+            timeout=5,
+        )
+        resp.raise_for_status()
+    except requests.RequestException as exc:
+        print(f"❌ Fehler beim Abrufen der Kartenvorschläge: {exc}")
+        return []
+    data = resp.json()
+    return data.get("data", [])
+
 def scan_and_queue(image_path: str) -> None:
     """Scan a card from an image and put its info into the queue."""
     card_id = scan_image(image_path)

--- a/docs/WEB_INTERFACE.md
+++ b/docs/WEB_INTERFACE.md
@@ -33,6 +33,8 @@ The **Cards** page shows the current inventory. Use the search field to filter b
 - *Cardmarket ID* – Optional link to the Cardmarket entry.
 - *Folder* – Assign the card to a folder (set) if one exists.
 
+When typing the name a list of suggestions from the Scryfall API appears for quick selection.
+
 To change an existing card, click **Edit** next to the card and modify the fields in the form.
 
 ## Bulk adding cards

--- a/templates/card_form.html
+++ b/templates/card_form.html
@@ -4,7 +4,8 @@
 <form method="post">
   <div class="mb-3">
     <label class="form-label">Name</label>
-    <input class="form-control" name="name" value="{{ card[1] if card else '' }}" required>
+    <input id="name-input" class="form-control" name="name" list="name-options" value="{{ card[1] if card else '' }}" required>
+    <datalist id="name-options"></datalist>
   </div>
   <div class="mb-3">
     <label class="form-label">Language</label>
@@ -39,4 +40,32 @@
   {% endif %}
   <button type="submit" class="btn btn-primary">Save</button>
 </form>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  const nameInput = document.getElementById('name-input');
+  const dataList = document.getElementById('name-options');
+  let timeout = null;
+
+  nameInput.addEventListener('input', function() {
+    clearTimeout(timeout);
+    const query = this.value.trim();
+    if (query.length < 2) {
+      dataList.innerHTML = '';
+      return;
+    }
+    timeout = setTimeout(function() {
+      fetch(`/api/autocomplete?q=${encodeURIComponent(query)}`)
+        .then(resp => resp.json())
+        .then(data => {
+          dataList.innerHTML = '';
+          data.forEach(name => {
+            const option = document.createElement('option');
+            option.value = name;
+            dataList.appendChild(option);
+          });
+        });
+    }, 300);
+  });
+});
+</script>
 {% endblock %}

--- a/web.py
+++ b/web.py
@@ -1,6 +1,6 @@
 import os
 import sqlite3
-from flask import Flask, render_template, request, redirect, url_for, flash
+from flask import Flask, render_template, request, redirect, url_for, flash, jsonify
 
 from TCGInventory.lager_manager import (
     add_card,
@@ -10,7 +10,7 @@ from TCGInventory.lager_manager import (
     add_folder,
     list_folders,
 )
-from TCGInventory.card_scanner import fetch_card_info_by_name
+from TCGInventory.card_scanner import fetch_card_info_by_name, autocomplete_names
 from TCGInventory.setup_db import initialize_database
 from TCGInventory import DB_FILE
 
@@ -56,6 +56,15 @@ def get_card(card_id: int):
             (card_id,),
         )
         return c.fetchone()
+
+
+@app.route("/api/autocomplete")
+def autocomplete_api():
+    """Return card name suggestions for the given query."""
+    query = request.args.get("q", "")
+    if not query:
+        return jsonify([])
+    return jsonify(autocomplete_names(query))
 
 
 @app.route("/")


### PR DESCRIPTION
## Summary
- add Scryfall autocomplete function in `card_scanner`
- expose `/api/autocomplete` endpoint in `web.py`
- enable dropdown suggestions in the card form
- document the new feature

## Testing
- `PYTHONPATH=$PWD python TCGInventory/test.py`

------
https://chatgpt.com/codex/tasks/task_e_6852ea388e70832b8da684d5b7d79852