### PR TITLE
Disable mandatory storage slots

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,11 @@ Run the CLI via the module path so Python can resolve the ``TCGInventory`` packa
 python -m TCGInventory.cli
 ```
 
-The CLI automatically manages storage slots.  Create binders for each set using
-option ``Ordner anlegen``.  Specify the set code and the number of pages; each
-page provides nine slots.  When you add a card without specifying a storage
-code, the next free slot in the corresponding binder will be used.
+
+The CLI can manage optional storage slots for physical binders.  Use option
+``Ordner anlegen`` to create slots for a set (one page equals nine slots).  When
+adding a card without a storage code, the next free slot will be used if
+available.  If no slot exists the card is still stored without a location.
 
 
 


### PR DESCRIPTION
## Summary
- allow adding cards even if no storage slot exists
- clarify in README that storage slots are optional

## Testing
- `python -m TCGInventory.setup_db`
- `PYTHONPATH=. python TCGInventory/test.py`

------
https://chatgpt.com/codex/tasks/task_e_6852ed5d8cdc832b85f934255dd38587