### PR TITLE
Use local Scryfall dump

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,4 +64,7 @@ For a detailed walkthrough of the available pages and forms, see [docs/WEB_INTER
 
 ## Autocomplete
 
-When adding a card through the web interface the **Name** field now shows suggestions provided by the Scryfall API. Start typing to get a dropdown list of matching card names.
+The application can provide name suggestions when adding a card.  Download the
+Scryfall ``default-cards`` JSON manually and place it in ``TCGInventory/data`` as
+``default-cards.json``.  If this file exists, suggestions and card lookups are
+served from the local data; otherwise the Scryfall API is used as fallback.

--- a/docs/WEB_INTERFACE.md
+++ b/docs/WEB_INTERFACE.md
@@ -33,7 +33,9 @@ The **Cards** page shows the current inventory. Use the search field to filter b
 - *Cardmarket ID* – Optional link to the Cardmarket entry.
 - *Folder* – Assign the card to a folder (set) if one exists.
 
-When typing the name a list of suggestions from the Scryfall API appears for quick selection.
+When typing the name a list of suggestions appears.  If
+``TCGInventory/data/default-cards.json`` is present the suggestions are loaded
+from that file; otherwise they are retrieved from the Scryfall API.
 
 To change an existing card, click **Edit** next to the card and modify the fields in the form.
 


### PR DESCRIPTION
## Summary
- support loading `default-cards.json` from `data/`
- document how to use the local card dump for autocomplete
- adjust web interface docs

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m TCGInventory.setup_db`
- `python -m TCGInventory.test`

------
https://chatgpt.com/codex/tasks/task_e_6853d1e79798832b90ddb9cbfb089b93