### PR TITLE
Implement offline card lookup using SQLite

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,5 +66,6 @@ For a detailed walkthrough of the available pages and forms, see [docs/WEB_INTER
 
 The application can provide name suggestions when adding a card.  Download the
 Scryfall ``default-cards`` JSON manually and place it in ``TCGInventory/data`` as
-``default-cards.json``.  If this file exists, suggestions and card lookups are
-served from the local data; otherwise the Scryfall API is used as fallback.
+``default-cards.json``.  Run ``python -m TCGInventory.build_card_db`` once to
+convert the JSON file into ``default-cards.db`` which enables fast offline
+search. If no database is available the Scryfall API is used as fallback.

--- a/build_card_db.py
+++ b/build_card_db.py
@@ -1,0 +1,54 @@
+import json
+import sqlite3
+from pathlib import Path
+
+DATA_DIR = Path(__file__).resolve().parent / "data"
+JSON_PATH = DATA_DIR / "default-cards.json"
+DB_PATH = DATA_DIR / "default-cards.db"
+
+
+def import_cards(json_path: Path = JSON_PATH, db_path: Path = DB_PATH) -> None:
+    """Import Scryfall card data from JSON into a SQLite database."""
+    if not json_path.exists():
+        raise FileNotFoundError(json_path)
+    cards = json.loads(json_path.read_text(encoding="utf-8"))
+    with sqlite3.connect(db_path) as conn:
+        c = conn.cursor()
+        c.execute(
+            """
+            CREATE TABLE IF NOT EXISTS cards (
+                id TEXT PRIMARY KEY,
+                name TEXT,
+                set_code TEXT,
+                lang TEXT,
+                collector_number TEXT,
+                cardmarket_id TEXT,
+                image_url TEXT
+            )
+            """
+        )
+        c.execute("CREATE INDEX IF NOT EXISTS idx_name ON cards(name)")
+        c.execute("DELETE FROM cards")
+        for card in cards:
+            image_url = ""
+            if isinstance(card.get("image_uris"), dict):
+                image_url = card["image_uris"].get("normal") or card["image_uris"].get("small") or ""
+            c.execute(
+                """INSERT OR REPLACE INTO cards (id, name, set_code, lang, collector_number, cardmarket_id, image_url)
+                   VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    card.get("id"),
+                    card.get("name"),
+                    card.get("set"),
+                    card.get("lang"),
+                    card.get("collector_number", ""),
+                    str(card.get("cardmarket_id", "")),
+                    image_url,
+                ),
+            )
+        conn.commit()
+
+
+if __name__ == "__main__":
+    import_cards()
+    print(f"Database written to {DB_PATH}")

--- a/docs/WEB_INTERFACE.md
+++ b/docs/WEB_INTERFACE.md
@@ -33,9 +33,14 @@ The **Cards** page shows the current inventory. Use the search field to filter b
 - *Cardmarket ID* – Optional link to the Cardmarket entry.
 - *Folder* – Assign the card to a folder (set) if one exists.
 
-When typing the name a list of suggestions appears.  If
-``TCGInventory/data/default-cards.json`` is present the suggestions are loaded
-from that file; otherwise they are retrieved from the Scryfall API.
+When typing the name a list of suggestions appears.  Place the Scryfall
+``default-cards.json`` in ``TCGInventory/data`` and convert it with
+``python -m TCGInventory.build_card_db``.  Suggestions and automatic
+card lookups are then served from the local SQLite database without
+internet access.  If no local data is found the Scryfall API is used as
+fallback.
+Selecting a suggested entry automatically fills language and ID fields. If
+multiple versions exist a second dropdown lets you choose the exact variant.
 
 To change an existing card, click **Edit** next to the card and modify the fields in the form.
 

--- a/lager_manager.py
+++ b/lager_manager.py
@@ -30,6 +30,9 @@ ALLOWED_FIELDS = {
     "folder_id",
     "status",
     "date_added",
+    "collector_number",
+    "scryfall_id",
+    "image_url",
 }
 
 # 📦 Funktion: Karte hinzufügen
@@ -42,6 +45,9 @@ def add_card(
     storage_code=None,
     cardmarket_id="",
     folder_id=None,
+    collector_number="",
+    scryfall_id="",
+    image_url="",
 ):
     """Add a card and reserve a storage slot if available."""
     if not storage_code:
@@ -63,8 +69,10 @@ def add_card(
 
         cursor.execute(
             """
-        INSERT INTO cards (name, set_code, language, condition, price, storage_code, cardmarket_id, date_added, folder_id)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        INSERT INTO cards (name, set_code, language, condition, price, storage_code,
+                           cardmarket_id, date_added, folder_id, collector_number,
+                           scryfall_id, image_url)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
             (
                 name,
@@ -76,6 +84,9 @@ def add_card(
                 cardmarket_id,
                 datetime.now().isoformat(),
                 folder_id,
+                collector_number,
+                scryfall_id,
+                image_url,
             ),
         )
 

--- a/setup_db.py
+++ b/setup_db.py
@@ -22,7 +22,10 @@ def initialize_database() -> None:
                 cardmarket_id TEXT,
                 folder_id INTEGER,
                 status TEXT DEFAULT 'verfügbar',
-                date_added TEXT
+                date_added TEXT,
+                collector_number TEXT,
+                scryfall_id TEXT,
+                image_url TEXT
             )
             """
         )
@@ -41,6 +44,12 @@ def initialize_database() -> None:
         columns = [row[1] for row in cursor.fetchall()]
         if "folder_id" not in columns:
             cursor.execute("ALTER TABLE cards ADD COLUMN folder_id INTEGER")
+        if "collector_number" not in columns:
+            cursor.execute("ALTER TABLE cards ADD COLUMN collector_number TEXT")
+        if "scryfall_id" not in columns:
+            cursor.execute("ALTER TABLE cards ADD COLUMN scryfall_id TEXT")
+        if "image_url" not in columns:
+            cursor.execute("ALTER TABLE cards ADD COLUMN image_url TEXT")
 
         # Tabelle 2: Lagerplätze
         cursor.execute(

--- a/templates/card_form.html
+++ b/templates/card_form.html
@@ -27,6 +27,18 @@
     <label class="form-label">Cardmarket ID</label>
     <input class="form-control" name="cardmarket_id" value="{{ card[7] if card else '' }}">
   </div>
+  <div class="mb-3">
+    <label class="form-label">Collector Number</label>
+    <input class="form-control" name="collector_number" value="{{ card[9] if card else '' }}">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Scryfall ID</label>
+    <input class="form-control" name="scryfall_id" value="{{ card[10] if card else '' }}">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Image URL</label>
+    <input class="form-control" name="image_url" value="{{ card[11] if card else '' }}">
+  </div>
   {% if folders is not none %}
   <div class="mb-3">
     <label class="form-label">Folder (Set)</label>
@@ -38,12 +50,14 @@
     </select>
   </div>
   {% endif %}
+  <select id="variant-select" class="form-select mb-3 d-none"></select>
   <button type="submit" class="btn btn-primary">Save</button>
 </form>
 <script>
 document.addEventListener('DOMContentLoaded', function() {
   const nameInput = document.getElementById('name-input');
   const dataList = document.getElementById('name-options');
+  const variantSelect = document.getElementById('variant-select');
   let timeout = null;
 
   nameInput.addEventListener('input', function() {
@@ -66,6 +80,49 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     }, 300);
   });
+
+  nameInput.addEventListener('change', lookupCard);
+  variantSelect.addEventListener('change', function() {
+    if (this.value) fillFields(JSON.parse(this.value));
+  });
+
+  function lookupCard() {
+    const q = nameInput.value.trim();
+    if (!q) return;
+    fetch(`/api/lookup?name=${encodeURIComponent(q)}`)
+      .then(resp => resp.json())
+      .then(list => {
+        if (!Array.isArray(list) || !list.length) return;
+        if (list.length === 1) {
+          variantSelect.classList.add('d-none');
+          fillFields(list[0]);
+        } else {
+          variantSelect.innerHTML = '';
+          list.forEach(info => {
+            const opt = document.createElement('option');
+            opt.value = JSON.stringify(info);
+            opt.textContent = `${info.set_code} (${info.language})`;
+            variantSelect.appendChild(opt);
+          });
+          variantSelect.classList.remove('d-none');
+          fillFields(list[0]);
+        }
+      });
+  }
+
+  function fillFields(info) {
+    document.querySelector('input[name=language]').value = info.language || '';
+    document.querySelector('input[name=cardmarket_id]').value = info.cardmarket_id || '';
+    document.querySelector('input[name=collector_number]').value = info.collector_number || '';
+    document.querySelector('input[name=scryfall_id]').value = info.scryfall_id || '';
+    document.querySelector('input[name=image_url]').value = info.image_url || '';
+    const folderSel = document.querySelector('select[name=folder_id]');
+    if (folderSel) {
+      for (const opt of folderSel.options) {
+        if (opt.text === info.set_code) { opt.selected = true; break; }
+      }
+    }
+  }
 });
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- import Scryfall `default-cards.json` into a local SQLite DB
- load card data from the DB for autocomplete and lookup
- auto-fill form fields using fetched card details
- extend card schema with collector number, Scryfall ID and image URL
- document the new offline workflow

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68541eab6cec832b85ce6eb3d71d5939