### PR TITLE
Code cleanup with ruff

### DIFF
--- a/card_scanner.py
+++ b/card_scanner.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from queue import Queue
-from typing import Dict, Optional, List, Iterable
+from typing import Dict, Optional, List
 
 import json
 import sqlite3
@@ -149,7 +149,7 @@ def fetch_card_info_by_name(name: str) -> Optional[CardInfo]:
 
     try:
         resp = requests.get(
-            f"https://api.scryfall.com/cards/named", params={"exact": name}, timeout=5
+            "https://api.scryfall.com/cards/named", params={"exact": name}, timeout=5
         )
         resp.raise_for_status()
     except requests.RequestException as exc:

--- a/cli.py
+++ b/cli.py
@@ -2,7 +2,6 @@ import os
 
 from TCGInventory.lager_manager import (
     add_card,
-    add_storage_slot,
     create_binder,
     update_card,
     delete_card,


### PR DESCRIPTION
## Summary
- run `ruff --fix` to clean up unused imports and extraneous `f` strings
- keep compile checks passing

## Testing
- `python -m compileall -q .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_685434231d4c832bb89741710baf2f1d