### PR TITLE
Fix SQLite threading and add condition dropdown

### DIFF
--- a/card_scanner.py
+++ b/card_scanner.py
@@ -34,7 +34,8 @@ def _load_card_database() -> None:
     if _DB_CONN:
         return
     if DEFAULT_DB_PATH.exists():
-        _DB_CONN = sqlite3.connect(DEFAULT_DB_PATH)
+        # allow usage across threads when served via Flask
+        _DB_CONN = sqlite3.connect(DEFAULT_DB_PATH, check_same_thread=False)
         _DB_CONN.row_factory = sqlite3.Row
         try:
             _DB_CONN.execute("SELECT 1 FROM cards LIMIT 1")

--- a/templates/card_form.html
+++ b/templates/card_form.html
@@ -13,7 +13,12 @@
   </div>
   <div class="mb-3">
     <label class="form-label">Condition</label>
-    <input class="form-control" name="condition" value="{{ card[4] if card else '' }}">
+    <select class="form-select" name="condition">
+      {% set cond = card[4] if card else '' %}
+      {% for c in ['MT', 'NM', 'EX', 'GD', 'LP', 'PL', 'PO'] %}
+      <option value="{{ c }}" {% if cond==c %}selected{% endif %}>{{ c }}</option>
+      {% endfor %}
+    </select>
   </div>
   <div class="mb-3">
     <label class="form-label">Price</label>


### PR DESCRIPTION
## Summary
- open default card DB connection with `check_same_thread=False`
- use a dropdown for card condition options in the web form

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685440f992f8832ba0a0aeb656b97a13