### PR TITLE
Automate binder slot assignment

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6,6 +6,7 @@ from TCGInventory.lager_manager import (
     update_card,
     delete_card,
     list_all_cards,
+    add_folder,
 )
 from TCGInventory.setup_db import initialize_database
 from TCGInventory import DB_FILE
@@ -83,9 +84,11 @@ def run():
                 delete_card(card_id)
 
             elif choice == "5":
-                set_code = input("Set-Code für den Ordner: ")
+                name = input("Set-Code für den Ordner: ")
                 pages = _get_int("Anzahl Seiten: ")
-                create_binder(set_code, pages)
+                folder_id = add_folder(name)
+                if folder_id is not None:
+                    create_binder(folder_id, pages)
 
             elif choice == "0":
                 print("👋 Programm beendet.")

--- a/templates/card_form.html
+++ b/templates/card_form.html
@@ -26,7 +26,17 @@
   </div>
   <div class="mb-3">
     <label class="form-label">Storage Code (optional)</label>
-    <input class="form-control" name="storage_code" value="{{ card[6] if card else '' }}">
+    <div class="row g-2">
+      <div class="col-auto">
+        <input class="form-control" name="folder_part" readonly value="{{ folder_part }}" placeholder="Ordner">
+      </div>
+      <div class="col-auto">
+        <input class="form-control" name="page" value="{{ page }}" placeholder="Seite">
+      </div>
+      <div class="col-auto">
+        <input class="form-control" name="slot" value="{{ slot }}" placeholder="Platz" min="1" max="9">
+      </div>
+    </div>
   </div>
   <div class="mb-3">
     <label class="form-label">Cardmarket ID</label>
@@ -63,6 +73,8 @@ document.addEventListener('DOMContentLoaded', function() {
   const nameInput = document.getElementById('name-input');
   const dataList = document.getElementById('name-options');
   const variantSelect = document.getElementById('variant-select');
+  const folderSel = document.querySelector('select[name=folder_id]');
+  const folderPart = document.querySelector('input[name=folder_part]');
   let timeout = null;
 
   nameInput.addEventListener('input', function() {
@@ -85,6 +97,15 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     }, 300);
   });
+
+  function updateFolderPart() {
+    if (folderSel) {
+      const fid = folderSel.value;
+      folderPart.value = fid ? `O${String(fid).padStart(2, '0')}` : '';
+    }
+  }
+  updateFolderPart();
+  if (folderSel) folderSel.addEventListener('change', updateFolderPart);
 
   nameInput.addEventListener('change', lookupCard);
   variantSelect.addEventListener('change', function() {

--- a/test.py
+++ b/test.py
@@ -1,7 +1,7 @@
 from TCGInventory.lager_manager import add_storage_slot, add_card, list_all_cards
 
 # Lagerplatz anlegen
-add_storage_slot("O01-S01-H01")
+add_storage_slot("O01-S01-P1")
 
 # Karte hinzufügen
 add_card(
@@ -10,7 +10,7 @@ add_card(
     language="Deutsch",
     condition="Near Mint",
     price=1.50,
-    storage_code="O01-S01-H01",
+    storage_code="O01-S01-P1",
     cardmarket_id="123456"
 )
 


### PR DESCRIPTION
## Summary
- auto-create binder storage codes using folder/page/slot pattern
- update CLI binder creation workflow
- expand card form with separate folder/page/slot fields
- handle new storage code logic in web views
- adjust example test script

## Testing
- `python -m TCGInventory.setup_db`
- `python -m TCGInventory.test`


------
https://chatgpt.com/codex/tasks/task_e_6855508f2d9c832b9dd6322d6719ab6c