### PR TITLE
Add binder pages to folder creation

### DIFF
--- a/docs/WEB_INTERFACE.md
+++ b/docs/WEB_INTERFACE.md
@@ -50,5 +50,5 @@ Use the **Bulk Add** page to quickly insert many cards. Enter one card name per 
 
 ## Managing folders
 
-Folders correspond to sets or binders. The **Folders** page lists all folders and the cards stored inside each one. Click **Add Folder** to create a new folder by specifying its name or set code. Cards can be assigned to a folder when adding or editing them.
+Folders correspond to sets or binders. The **Folders** page lists all folders and the cards stored inside each one. When clicking **Add Folder** you can enter a name and the number of pages of the binder. Each page provides nine storage slots.  Cards can then be assigned to a folder and stored on a specific page and slot when adding or editing them.
 

--- a/templates/folder_form.html
+++ b/templates/folder_form.html
@@ -6,6 +6,10 @@
     <label class="form-label">Name</label>
     <input class="form-control" name="name" required>
   </div>
+  <div class="mb-3">
+    <label class="form-label">Pages</label>
+    <input type="number" class="form-control" name="pages" min="1" value="1" required>
+  </div>
   <button type="submit" class="btn btn-primary">Add</button>
 </form>
 {% endblock %}

--- a/web.py
+++ b/web.py
@@ -9,6 +9,7 @@ from TCGInventory.lager_manager import (
     delete_card,
     add_storage_slot,
     add_folder,
+    create_binder,
     list_folders,
 )
 from TCGInventory.card_scanner import (
@@ -206,7 +207,14 @@ def list_folders_view():
 @app.route("/folders/add", methods=["GET", "POST"])
 def add_folder_view():
     if request.method == "POST":
-        add_folder(request.form["name"])
+        name = request.form["name"]
+        pages = request.form.get("pages", "1")
+        folder_id = add_folder(name)
+        if folder_id is not None:
+            try:
+                create_binder(folder_id, int(pages))
+            except ValueError:
+                pass
         flash("Folder added")
         return redirect(url_for("list_folders_view"))
     return render_template("folder_form.html")


### PR DESCRIPTION
## Summary
- let web UI create binder slots when adding a folder
- ask for number of pages when creating a folder
- document binder creation in web interface docs

## Testing
- `python -m TCGInventory.test`

------
https://chatgpt.com/codex/tasks/task_e_685558732e3c832ba741631fb0d79d75