### PR TITLE
Display folder IDs in forms

### DIFF
--- a/templates/bulk_add.html
+++ b/templates/bulk_add.html
@@ -7,7 +7,7 @@
     <select name="folder_id" class="form-select">
       <option value="">-- none --</option>
       {% for f in folders %}
-      <option value="{{ f[0] }}">{{ f[1] }}</option>
+      <option value="{{ f[0] }}">{{ f[1] }} ({{ '%02d'|format(f[0]) }})</option>
       {% endfor %}
     </select>
   </div>

--- a/templates/card_form.html
+++ b/templates/card_form.html
@@ -61,7 +61,7 @@
     <select name="folder_id" class="form-select">
       <option value="">-- none --</option>
       {% for f in folders %}
-      <option value="{{ f[0] }}" {% if card and card[8]==f[0] %}selected{% endif %}>{{ f[1] }}</option>
+      <option value="{{ f[0] }}" {% if card and card[8]==f[0] %}selected{% endif %}>{{ f[1] }} ({{ '%02d'|format(f[0]) }})</option>
       {% endfor %}
     </select>
   </div>

--- a/templates/folders.html
+++ b/templates/folders.html
@@ -2,7 +2,7 @@
 {% block content %}
 <h2 class="mb-4">Folders</h2>
 {% for f in folders %}
-  <h4 class="mt-4">{{ f[1] }}</h4>
+  <h4 class="mt-4">{{ f[1] }} ({{ '%02d'|format(f[0]) }})</h4>
   <table class="table table-sm table-striped">
     <tr><th>ID</th><th>Name</th><th>Set</th><th>Storage</th></tr>
     {% for c in folder_cards.get(f[0], []) %}


### PR DESCRIPTION
## Summary
- show folder IDs next to folder names in card form
- show folder IDs in bulk add form
- show folder IDs on folder overview

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6855591a623c832b92378a9f564dbe19