### PR TITLE
Add card quantity support

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -59,12 +59,14 @@ def run():
                 language = input("Sprache: ")
                 condition = input("Zustand (z. B. Near Mint): ")
                 price = _get_float("Preis (€): ")
+                quantity = _get_int("Anzahl: ")
                 add_card(
                     name,
                     set_code,
                     language,
                     condition,
                     price,
+                    quantity,
                 )
 
             elif choice == "2":

--- a/docs/WEB_INTERFACE.md
+++ b/docs/WEB_INTERFACE.md
@@ -29,6 +29,7 @@ The **Cards** page shows the current inventory. Use the search field to filter b
 - *Language* – Language of the card, e.g. `EN` or `DE`.
 - *Condition* – Condition such as `Near Mint`.
 - *Price* – Price in Euro; use `0` if unknown.
+- *Quantity* – Number of copies to add.
 - *Storage Code* – Optional storage slot identifier.
 - *Cardmarket ID* – Optional link to the Cardmarket entry.
 - *Folder* – Assign the card to a folder (set) if one exists.

--- a/lager_manager.py
+++ b/lager_manager.py
@@ -25,6 +25,7 @@ ALLOWED_FIELDS = {
     "language",
     "condition",
     "price",
+    "quantity",
     "storage_code",
     "cardmarket_id",
     "folder_id",
@@ -42,6 +43,7 @@ def add_card(
     language,
     condition,
     price,
+    quantity=1,
     storage_code=None,
     cardmarket_id="",
     folder_id=None,
@@ -71,10 +73,10 @@ def add_card(
 
         cursor.execute(
             """
-        INSERT INTO cards (name, set_code, language, condition, price, storage_code,
+        INSERT INTO cards (name, set_code, language, condition, price, quantity, storage_code,
                            cardmarket_id, date_added, folder_id, collector_number,
                            scryfall_id, image_url)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
             (
                 name,
@@ -82,6 +84,7 @@ def add_card(
                 language,
                 condition,
                 price,
+                quantity,
                 storage_code,
                 cardmarket_id,
                 datetime.now().isoformat(),
@@ -141,7 +144,7 @@ def list_all_cards():
         cursor.execute(
             """
             SELECT cards.id, cards.name, cards.set_code, cards.language,
-                   cards.condition, cards.price, cards.storage_code,
+                   cards.condition, cards.price, cards.quantity, cards.storage_code,
                    COALESCE(folders.name, ''), cards.status
             FROM cards
             LEFT JOIN folders ON cards.folder_id = folders.id
@@ -158,6 +161,7 @@ def list_all_cards():
             "Sprache",
             "Zustand",
             "Preis (€)",
+            "Anzahl",
             "Lagerplatz",
             "Ordner",
             "Status",

--- a/setup_db.py
+++ b/setup_db.py
@@ -18,6 +18,7 @@ def initialize_database() -> None:
                 language TEXT,
                 condition TEXT,
                 price REAL,
+                quantity INTEGER DEFAULT 1,
                 storage_code TEXT,
                 cardmarket_id TEXT,
                 folder_id INTEGER,
@@ -50,6 +51,8 @@ def initialize_database() -> None:
             cursor.execute("ALTER TABLE cards ADD COLUMN scryfall_id TEXT")
         if "image_url" not in columns:
             cursor.execute("ALTER TABLE cards ADD COLUMN image_url TEXT")
+        if "quantity" not in columns:
+            cursor.execute("ALTER TABLE cards ADD COLUMN quantity INTEGER DEFAULT 1")
 
         # Tabelle 2: Lagerplätze
         cursor.execute(

--- a/templates/card_form.html
+++ b/templates/card_form.html
@@ -7,7 +7,7 @@
     <input id="name-input" class="form-control" autocomplete="off" name="name" value="{{ card[1] if card else '' }}" required>
     <div id="name-suggestions" class="dropdown-menu w-100"></div>
   </div>
-  <img id="preview-image" class="img-thumbnail mb-3{% if not card or not card[11] %} d-none{% endif %}" style="max-width:200px;" src="{{ card[11] if card else '' }}">
+  <img id="preview-image" class="img-thumbnail mb-3{% if not card or not card[12] %} d-none{% endif %}" style="max-width:200px;" src="{{ card[12] if card else '' }}">
   <div class="mb-3">
     <label class="form-label">Language</label>
     <input class="form-control" name="language" value="{{ card[3] if card else '' }}">
@@ -26,6 +26,10 @@
     <input type="number" step="0.01" class="form-control" name="price" value="{{ card[5] if card else '' }}">
   </div>
   <div class="mb-3">
+    <label class="form-label">Quantity</label>
+    <input type="number" class="form-control" name="quantity" min="1" value="{{ card[6] if card else 1 }}">
+  </div>
+  <div class="mb-3">
     <label class="form-label">Storage Code (optional)</label>
     <div class="row g-2">
       <div class="col-auto">
@@ -41,19 +45,19 @@
   </div>
   <div class="mb-3">
     <label class="form-label">Cardmarket ID</label>
-    <input class="form-control" name="cardmarket_id" value="{{ card[7] if card else '' }}">
+    <input class="form-control" name="cardmarket_id" value="{{ card[8] if card else '' }}">
   </div>
   <div class="mb-3">
     <label class="form-label">Collector Number</label>
-    <input class="form-control" name="collector_number" value="{{ card[9] if card else '' }}">
+    <input class="form-control" name="collector_number" value="{{ card[10] if card else '' }}">
   </div>
   <div class="mb-3">
     <label class="form-label">Scryfall ID</label>
-    <input class="form-control" name="scryfall_id" value="{{ card[10] if card else '' }}">
+    <input class="form-control" name="scryfall_id" value="{{ card[11] if card else '' }}">
   </div>
   <div class="mb-3">
     <label class="form-label">Image URL</label>
-    <input class="form-control" name="image_url" value="{{ card[11] if card else '' }}">
+    <input class="form-control" name="image_url" value="{{ card[12] if card else '' }}">
   </div>
   {% if folders is not none %}
   <div class="mb-3">
@@ -61,7 +65,7 @@
     <select name="folder_id" class="form-select">
       <option value="">-- none --</option>
       {% for f in folders %}
-      <option value="{{ f[0] }}" {% if card and card[8]==f[0] %}selected{% endif %}>{{ f[1] }} ({{ '%02d'|format(f[0]) }})</option>
+      <option value="{{ f[0] }}" {% if card and card[9]==f[0] %}selected{% endif %}>{{ f[1] }} ({{ '%02d'|format(f[0]) }})</option>
       {% endfor %}
     </select>
   </div>

--- a/templates/cards.html
+++ b/templates/cards.html
@@ -9,11 +9,11 @@
   <div id="search-suggestions" class="dropdown-menu w-100"></div>
 </form>
 <table class="table table-striped">
-<tr><th>ID</th><th>Image</th><th>Name</th><th>Set</th><th>Lang</th><th>Condition</th><th>Price</th><th>Storage</th><th>Folder</th><th>Status</th><th>Actions</th></tr>
+<tr><th>ID</th><th>Image</th><th>Name</th><th>Set</th><th>Lang</th><th>Condition</th><th>Price</th><th>Qty</th><th>Storage</th><th>Folder</th><th>Status</th><th>Actions</th></tr>
 {% for c in cards %}
 <tr>
 <td>{{ c[0] }}</td>
-<td>{% if c[9] %}<img src="{{ c[9] }}" style="max-height:80px;" class="img-thumbnail">{% endif %}</td>
+<td>{% if c[10] %}<img src="{{ c[10] }}" style="max-height:80px;" class="img-thumbnail">{% endif %}</td>
 <td>{{ c[1] }}</td>
 <td>{{ c[2] }}</td>
 <td>{{ c[3] }}</td>
@@ -22,6 +22,7 @@
 <td>{{ c[6] }}</td>
 <td>{{ c[7] }}</td>
 <td>{{ c[8] }}</td>
+<td>{{ c[9] }}</td>
 <td><a class="btn btn-sm btn-outline-primary" href="{{ url_for('edit_card_view', card_id=c[0]) }}">Edit</a> <a class="btn btn-sm btn-outline-danger" href="{{ url_for('delete_card_route', card_id=c[0]) }}">Delete</a></td>
 </tr>
 {% endfor %}

--- a/templates/folders.html
+++ b/templates/folders.html
@@ -4,17 +4,18 @@
 {% for f in folders %}
   <h4 class="mt-4">{{ f[1] }} ({{ '%02d'|format(f[0]) }})</h4>
   <table class="table table-sm table-striped">
-    <tr><th>ID</th><th>Name</th><th>Set</th><th>Storage</th></tr>
+    <tr><th>ID</th><th>Name</th><th>Set</th><th>Qty</th><th>Storage</th></tr>
     {% for c in folder_cards.get(f[0], []) %}
     <tr>
       <td>{{ c[0] }}</td>
       <td>{{ c[1] }}</td>
       <td>{{ c[2] }}</td>
       <td>{{ c[3] }}</td>
+      <td>{{ c[4] }}</td>
     </tr>
     {% endfor %}
     {% if not folder_cards.get(f[0], []) %}
-    <tr><td colspan="4" class="text-muted">No cards</td></tr>
+    <tr><td colspan="5" class="text-muted">No cards</td></tr>
     {% endif %}
   </table>
 {% endfor %}

--- a/test.py
+++ b/test.py
@@ -10,6 +10,7 @@ add_card(
     language="Deutsch",
     condition="Near Mint",
     price=1.50,
+    quantity=1,
     storage_code="O01-S01-P1",
     cardmarket_id="123456"
 )


### PR DESCRIPTION
## Summary
- track a `quantity` for cards in the DB and forms
- update CLI and web UI to handle new field
- show quantity in inventory listings
- document new quantity option

## Testing
- `python -m compileall -q .`
- `pip install -r requirements.txt`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68555cd3ce58832bb2b8e9ca2b84735a