### PR TITLE
Make web interface accessible via network

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,15 @@ The application will initialize the SQLite database on first start if it does
 not exist.  Open ``http://localhost:5000`` in your browser to use the
 interface.
 
+To expose the web interface to the entire local network set ``FLASK_RUN_HOST``
+before running the command, for example:
+
+```bash
+FLASK_RUN_HOST=0.0.0.0 python web.py
+```
+
+Optionally change the port with ``FLASK_RUN_PORT``.
+
 For a detailed walkthrough of the available pages and forms, see [docs/WEB_INTERFACE.md](docs/WEB_INTERFACE.md).
 
 ## Autocomplete

--- a/docs/WEB_INTERFACE.md
+++ b/docs/WEB_INTERFACE.md
@@ -12,6 +12,8 @@ python web.py
 
 On first launch the SQLite database will be created automatically if it does not exist. Visit `http://localhost:5000` in your browser.
 
+To access the interface from another machine set `FLASK_RUN_HOST=0.0.0.0` when starting the server. You can also change the port with `FLASK_RUN_PORT`.
+
 ## Navigation
 
 The navigation bar at the top links to the most important pages:

--- a/web.py
+++ b/web.py
@@ -320,4 +320,6 @@ def bulk_add_view():
 
 if __name__ == "__main__":
     init_db()
-    app.run(debug=True)
+    host = os.environ.get("FLASK_RUN_HOST", "127.0.0.1")
+    port = int(os.environ.get("FLASK_RUN_PORT", 5000))
+    app.run(host=host, port=port, debug=True)


### PR DESCRIPTION
## Summary
- allow setting the host and port for the Flask app
- document how to expose the web interface on the local network

## Testing
- `python -m py_compile web.py`


------
https://chatgpt.com/codex/tasks/task_e_68555eebce24832ba36dc35b2ec3eb57