### PR TITLE
Fix folder name search

### DIFF
--- a/docs/WEB_INTERFACE.md
+++ b/docs/WEB_INTERFACE.md
@@ -54,5 +54,5 @@ Use the **Bulk Add** page to quickly insert many cards. Enter one card name per 
 ## Managing folders
 
 Folders correspond to sets or binders. The **Folders** page lists all folders and the cards stored inside each one. When clicking **Add Folder** you can enter a name and the number of pages of the binder. Each page provides nine storage slots.  Cards can then be assigned to a folder and stored on a specific page and slot when adding or editing them.
-The overview also offers a small form to filter the listed cards by ID or storage code and to sort them by name, ID or storage.
+The overview also offers a small form to filter the listed cards by name, ID or storage code and to sort them by name, ID or storage.
 

--- a/templates/folders.html
+++ b/templates/folders.html
@@ -4,7 +4,7 @@
 <form method="get" class="mb-3">
   <div class="row g-2">
     <div class="col">
-      <input class="form-control" type="text" name="q" placeholder="Filter by ID or Storage" value="{{ search }}">
+      <input class="form-control" type="text" name="q" placeholder="Filter by name, ID or storage" value="{{ search }}">
     </div>
     <div class="col-auto">
       <select class="form-select" name="sort">

--- a/web.py
+++ b/web.py
@@ -210,9 +210,11 @@ def list_folders_view():
             )
             params = [fid]
             if search:
-                query += " AND (CAST(id AS TEXT) LIKE ? OR storage_code LIKE ?)"
+                query += (
+                    " AND (CAST(id AS TEXT) LIKE ? OR storage_code LIKE ? OR name LIKE ?)"
+                )
                 like = f"%{search}%"
-                params.extend([like, like])
+                params.extend([like, like, like])
             query += f" ORDER BY {order_col}"
             c.execute(query, params)
             folder_cards[fid] = c.fetchall()


### PR DESCRIPTION
## Summary
- search cards by name on the Folders page
- update placeholder text for the search box
- document name filtering support

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685684b0ccd4832bb4397681c828be7b