### PR TITLE
Improve CSV parsing

### DIFF
--- a/docs/WEB_INTERFACE.md
+++ b/docs/WEB_INTERFACE.md
@@ -20,7 +20,7 @@ The navigation bar at the top links to the most important pages:
 
 - **Cards** – List all cards with a search field.
 - **Add Card** – Open a form to add a single card manually.
-- **Bulk Add** – Add many cards at once by entering a list of names or uploading a JSON file.
+- **Bulk Add** – Add many cards at once by entering a list of names or uploading a JSON or CSV file.
 - **Folders** – Manage folders (sets) and see which cards belong to each folder.
 
 ## Working with cards
@@ -49,7 +49,7 @@ To change an existing card, click **Edit** next to the card and modify the field
 
 ## Bulk adding cards
 
-Use the **Bulk Add** page to quickly insert many cards. Enter one card name per line or upload a JSON file containing a list of card names (or objects with a `name` field). The application tries to fetch additional information automatically if possible.
+Use the **Bulk Add** page to quickly insert many cards. Enter one card name per line or upload a JSON file containing a list of card names (or objects with a `name` field). Alternatively you can upload a CSV file with the columns `Card Name`, `Set Code`, `Card Number`, `Quantity` and `Language`. Additional columns are ignored. The application tries to fetch additional information automatically if possible. Files encoded as UTF‑8 or Latin‑1 are accepted and Excel's optional `sep=;` line is ignored.
 
 ## Managing folders
 

--- a/web.py
+++ b/web.py
@@ -313,17 +313,33 @@ def bulk_add_view():
         csv_file = request.files.get("csv_file")
         if csv_file and csv_file.filename:
             try:
-                content = csv_file.read().decode("utf-8-sig")
+                raw = csv_file.read()
                 try:
-                    dialect = csv.Sniffer().sniff(content, delimiters=",;")
+                    content = raw.decode("utf-8-sig")
+                except UnicodeDecodeError:
+                    content = raw.decode("latin-1")
+                lines = content.splitlines()
+                delimiter = None
+                if lines and lines[0].lower().startswith("sep="):
+                    delimiter = lines[0][4:].strip()
+                    content = "\n".join(lines[1:])
+                try:
+                    dialect = csv.Sniffer().sniff(content, delimiters=delimiter or ",;")
                 except csv.Error:
                     dialect = csv.excel
+                    if delimiter:
+                        dialect.delimiter = delimiter
                 reader = csv.DictReader(io.StringIO(content), dialect=dialect)
                 for row in reader:
-                    normalized = {
-                        (k or "").strip().lower().replace(" ", "_"): (v or "").strip()
-                        for k, v in row.items()
-                    }
+                    normalized = {}
+                    for k, v in row.items():
+                        if not k:
+                            # extra columns end up under the key ``None``
+                            # and may contain a list of values
+                            continue
+                        if isinstance(v, list):
+                            v = v[0] if v else ""
+                        normalized[k.strip().lower().replace(" ", "_")] = (v or "").strip()
                     name = normalized.get("card_name", "")
                     if not name:
                         continue
@@ -358,8 +374,8 @@ def bulk_add_view():
                         }
                     )
                     added_any = True
-            except Exception:
-                flash("Invalid CSV file")
+            except Exception as exc:
+                flash(f"Invalid CSV file: {exc}")
 
         # names from textarea
         for line in request.form.get("cards", "").splitlines():


### PR DESCRIPTION
## Summary
- skip extra columns when parsing CSVs
- note in docs that additional CSV columns are ignored

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6856b63312d4832bb9dc2dd4b7d6848c