### PR TITLE
Improve card image viewer

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -4,6 +4,9 @@
   <meta charset="utf-8">
   <title>TCG Inventory</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" rel="stylesheet">
+  <style>
+    .clickable-image { cursor: pointer; }
+  </style>
 </head>
 <body class="bg-light">
   <div class="container py-4">
@@ -33,5 +36,6 @@
     {% endwith %}
     {% block content %}{% endblock %}
   </div>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/templates/cards.html
+++ b/templates/cards.html
@@ -13,7 +13,7 @@
 {% for c in cards %}
 <tr>
 <td>{{ c[0] }}</td>
-<td>{% if c[10] %}<img src="{{ c[10] }}" style="max-height:80px;" class="img-thumbnail">{% endif %}</td>
+<td>{% if c[10] %}<img src="{{ c[10] }}" style="max-height:80px;" class="img-thumbnail clickable-image" data-bs-toggle="modal" data-bs-target="#imgModal" data-img="{{ c[10] }}">{% endif %}</td>
 <td>{{ c[1] }}</td>
 <td>{{ c[2] }}</td>
 <td>{{ c[3] }}</td>
@@ -27,10 +27,21 @@
 </tr>
 {% endfor %}
 </table>
+<div class="modal fade" id="imgModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content bg-dark">
+      <div class="modal-body p-0">
+        <img id="modal-img" src="" class="img-fluid" alt="Card image">
+      </div>
+    </div>
+  </div>
+</div>
 <script>
 document.addEventListener('DOMContentLoaded', function() {
   const input = document.getElementById('search-input');
   const list = document.getElementById('search-suggestions');
+  const modalImg = document.getElementById('modal-img');
+  const modal = new bootstrap.Modal(document.getElementById('imgModal'));
   let timeout = null;
 
   input.addEventListener('input', function() {
@@ -65,6 +76,13 @@ document.addEventListener('DOMContentLoaded', function() {
   document.addEventListener('click', (e) => {
     if (!input.contains(e.target) && !list.contains(e.target)) {
       list.classList.remove('show');
+    }
+    if (e.target.classList.contains('clickable-image')) {
+      const src = e.target.getAttribute('data-img');
+      if (src) {
+        modalImg.src = src;
+        modal.show();
+      }
     }
   });
 });


### PR DESCRIPTION
## Summary
- add clickable-image CSS style and bootstrap JS
- show card images in a modal overlay

## Testing
- `python -m py_compile web.py card_scanner.py auth.py cli.py lager_manager.py build_card_db.py setup_db.py cardmarket_api.py`

------
https://chatgpt.com/codex/tasks/task_e_6857270d24f8832baf76864a39af356e