### PR TITLE
Add folder-filtered CSV export

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,4 +86,4 @@ search. If no database is available the Scryfall API is used as fallback.
 
 ## Export
 
-Use the CLI option **Karten exportieren** or the *Export* link in the web interface to download all cards as a CSV file.
+Use the CLI option **Karten exportieren** or the *Export* link in the web interface to download the inventory as a CSV file. You can optionally export a single folder by specifying its name (CLI) or by using the folder-specific link in the web interface. The CSV uses a semicolon as separator for better compatibility with spreadsheet applications.

--- a/cli.py
+++ b/cli.py
@@ -149,8 +149,9 @@ def run():
                     create_binder(folder_id, pages)
 
             elif choice == "6":
+                folder = input("Ordnername für Export (leer = alle): ").strip() or None
                 path = input("Dateiname für CSV-Export [inventory.csv]: ").strip() or "inventory.csv"
-                export_inventory_csv(path)
+                export_inventory_csv(path, folder)
 
             elif choice == "0":
                 print(Fore.YELLOW + "👋 Programm beendet.")

--- a/lager_manager.py
+++ b/lager_manager.py
@@ -173,11 +173,11 @@ def list_all_cards():
         print("Keine Karten gefunden.")
 
 
-def export_inventory_csv(path: str) -> None:
-    """Write the current card list to a CSV file."""
+def export_inventory_csv(path: str, folder: str | None = None) -> None:
+    """Write the current card list to a CSV file, optionally filtered by folder."""
     with sqlite3.connect(DB_FILE) as conn, open(path, "w", newline="", encoding="utf-8") as f:
         cursor = conn.cursor()
-        cursor.execute(
+        query = (
             """
             SELECT cards.id, cards.name, cards.set_code, cards.language,
                    cards.condition, cards.price, cards.quantity, cards.storage_code,
@@ -186,7 +186,12 @@ def export_inventory_csv(path: str) -> None:
             LEFT JOIN folders ON cards.folder_id = folders.id
             """
         )
-        writer = csv.writer(f)
+        params: tuple = ()
+        if folder:
+            query += " WHERE folders.name = ?"
+            params = (folder,)
+        cursor.execute(query, params)
+        writer = csv.writer(f, delimiter=";")
         writer.writerow([
             "ID",
             "Name",

--- a/templates/folders.html
+++ b/templates/folders.html
@@ -21,6 +21,7 @@
 {% for f in folders %}
   <h4 class="mt-4">
     <button class="btn btn-sm btn-outline-secondary me-2 folder-toggle" data-target="folder-{{ f[0] }}">Hide</button>
+    <a href="{{ url_for('export_cards', folder=f[0]) }}" class="btn btn-sm btn-outline-secondary me-2">Export CSV</a>
     {{ f[1] }} ({{ '%02d'|format(f[0]) }})
   </h4>
   <div id="folder-{{ f[0] }}">


### PR DESCRIPTION
## Summary
- expand CSV export to accept optional folder filter and use semicolon separator
- update CLI to prompt for folder when exporting
- expose folder export via web interface
- add export links for each folder on the folder listing page
- document new options in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685860e9c9f0832bb659ed1e0a459dad