### PR TITLE
Fix CLI indentation

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -151,15 +151,16 @@ def run():
                     create_binder(folder_id, pages)
 
             elif choice == "6":
-              codex/erweiterte-exportfunktion-für-lager-hinzufügen
-                folder = input("Ordnername für Export (leer = alle): ").strip() or None
                 folder_id = _get_int("Ordner-ID zum Umbenennen: ")
                 new_name = input("Neuer Name: ")
                 rename_folder(folder_id, new_name)
 
             elif choice == "7":
-              main
-                path = input("Dateiname für CSV-Export [inventory.csv]: ").strip() or "inventory.csv"
+                folder = input("Ordnername für Export (leer = alle): ").strip() or None
+                path = (
+                    input("Dateiname für CSV-Export [inventory.csv]: ").strip()
+                    or "inventory.csv"
+                )
                 export_inventory_csv(path, folder)
 
             elif choice == "0":


### PR DESCRIPTION
## Summary
- fix stray lines and indentation in CLI

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m TCGInventory.test` *(fails: No module named 'tabulate')*

------
https://chatgpt.com/codex/tasks/task_e_685861f0e3d4832bbf03799c1b99b4f6