### PR TITLE
Implement folder editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ The CLI can manage optional storage slots for physical binders.  Use option
 ``Ordner anlegen`` to create slots for a set (one page equals nine slots).  When
 adding a card without a storage code, the next free slot will be used if
 available.  If no slot exists the card is still stored without a location.
+Existing folders can be edited via ``Ordner bearbeiten`` to change the name or
+page count without affecting the cards stored inside. Increasing the page count
+automatically creates additional storage slots.
 
 
 

--- a/cli.py
+++ b/cli.py
@@ -11,6 +11,8 @@ from TCGInventory.lager_manager import (
     delete_card,
     list_all_cards,
     add_folder,
+    edit_folder,
+    rename_folder,
     export_inventory_csv,
 )
 from TCGInventory.setup_db import initialize_database
@@ -64,7 +66,8 @@ def show_menu():
     print(Fore.YELLOW + "3. Karte bearbeiten")
     print(Fore.YELLOW + "4. Karte löschen")
     print(Fore.YELLOW + "5. Ordner anlegen")
-    print(Fore.YELLOW + "6. Karten exportieren")
+    print(Fore.YELLOW + "6. Ordner bearbeiten")
+    print(Fore.YELLOW + "7. Karten exportieren")
     print(Fore.YELLOW + "0. Beenden")
 
 
@@ -144,11 +147,17 @@ def run():
             elif choice == "5":
                 name = input("Set-Code für den Ordner: ")
                 pages = _get_int("Anzahl Seiten: ")
-                folder_id = add_folder(name)
+                folder_id = add_folder(name, pages)
                 if folder_id is not None:
                     create_binder(folder_id, pages)
 
             elif choice == "6":
+                folder_id = _get_int("Ordner-ID zum Bearbeiten: ")
+                new_name = input("Neuer Name: ")
+                new_pages = _get_int("Neue Seitenanzahl: ")
+                edit_folder(folder_id, new_name, new_pages)
+
+            elif choice == "7":
                 path = input("Dateiname für CSV-Export [inventory.csv]: ").strip() or "inventory.csv"
                 export_inventory_csv(path)
 

--- a/docs/WEB_INTERFACE.md
+++ b/docs/WEB_INTERFACE.md
@@ -58,6 +58,6 @@ After submitting the form the cards appear in the **Upload Queue** where each en
 
 ## Managing folders
 
-Folders correspond to sets or binders. The **Folders** page lists all folders and the cards stored inside each one. When clicking **Add Folder** you can enter a name and the number of pages of the binder. Each page provides nine storage slots.  Cards can then be assigned to a folder and stored on a specific page and slot when adding or editing them.
+Folders correspond to sets or binders. The **Folders** page lists all folders and the cards stored inside each one. When clicking **Add Folder** you can enter a name and the number of pages of the binder. Each page provides nine storage slots.  Cards can then be assigned to a folder and stored on a specific page and slot when adding or editing them. Existing folders can be edited using the **Edit** link next to each entry to change the name or page count. Increasing the number of pages automatically adds more storage slots.
 The overview also offers a small form to filter the listed cards by name, ID or storage code and to sort them by name, ID or storage.
 

--- a/lager_manager.py
+++ b/lager_manager.py
@@ -16,6 +16,8 @@ __all__ = [
     "delete_card",
     "get_next_free_slot",
     "add_folder",
+    "edit_folder",
+    "rename_folder",
     "list_folders",
     "export_inventory_csv",
 ]
@@ -262,15 +264,20 @@ def delete_card(card_id):
 # Folder helpers
 # ---------------------------------------------------------------------------
 
-def add_folder(name: str) -> int | None:
+def add_folder(name: str, pages: int = 0) -> int | None:
     """Create a folder entry if it does not exist and return its ID."""
     with sqlite3.connect(DB_FILE) as conn:
         cursor = conn.cursor()
-        cursor.execute("INSERT OR IGNORE INTO folders (name) VALUES (?)", (name,))
+        cursor.execute(
+            "INSERT OR IGNORE INTO folders (name, pages) VALUES (?, ?)",
+            (name, pages),
+        )
         conn.commit()
         cursor.execute("SELECT id FROM folders WHERE name = ?", (name,))
         row = cursor.fetchone()
         if row:
+            cursor.execute("UPDATE folders SET pages = ? WHERE id = ?", (pages, row[0]))
+            conn.commit()
             print(f"📁 Ordner '{name}' angelegt.")
             return row[0]
     return None
@@ -280,5 +287,36 @@ def list_folders():
     """Return a list of all folders."""
     with sqlite3.connect(DB_FILE) as conn:
         cursor = conn.cursor()
-        cursor.execute("SELECT id, name FROM folders ORDER BY name")
+        cursor.execute("SELECT id, name, pages FROM folders ORDER BY name")
         return cursor.fetchall()
+
+
+def rename_folder(folder_id: int, new_name: str) -> bool:
+    """Rename a folder without touching its cards."""
+    return edit_folder(folder_id, new_name)
+
+
+def edit_folder(folder_id: int, new_name: str, pages: int | None = None) -> bool:
+    """Update folder name and optionally adjust page count."""
+    with sqlite3.connect(DB_FILE) as conn:
+        cursor = conn.cursor()
+        cursor.execute("SELECT pages FROM folders WHERE id = ?", (folder_id,))
+        row = cursor.fetchone()
+        if not row:
+            print(f"⚠️ Kein Ordner mit ID {folder_id} gefunden.")
+            return False
+        current_pages = row[0] or 0
+        new_pages = pages if pages is not None else current_pages
+        cursor.execute(
+            "UPDATE folders SET name = ?, pages = ? WHERE id = ?",
+            (new_name, new_pages, folder_id),
+        )
+        conn.commit()
+        if new_pages > current_pages:
+            create_binder(folder_id, new_pages - current_pages)
+        if cursor.rowcount:
+            print(f"📁 Ordner {folder_id} aktualisiert.")
+            return True
+        print(f"⚠️ Kein Ordner mit ID {folder_id} gefunden.")
+        return False
+

--- a/setup_db.py
+++ b/setup_db.py
@@ -38,10 +38,16 @@ def initialize_database() -> None:
             """
             CREATE TABLE IF NOT EXISTS folders (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
-                name TEXT UNIQUE
+                name TEXT UNIQUE,
+                pages INTEGER DEFAULT 0
             )
             """
         )
+
+        cursor.execute("PRAGMA table_info(folders)")
+        folder_columns = [row[1] for row in cursor.fetchall()]
+        if "pages" not in folder_columns:
+            cursor.execute("ALTER TABLE folders ADD COLUMN pages INTEGER DEFAULT 0")
 
         cursor.execute("PRAGMA table_info(cards)")
         columns = [row[1] for row in cursor.fetchall()]

--- a/templates/folder_form.html
+++ b/templates/folder_form.html
@@ -1,15 +1,15 @@
 {% extends "base.html" %}
 {% block content %}
-<h2 class="mb-4">Add Folder</h2>
+<h2 class="mb-4">{{ 'Edit Folder' if folder else 'Add Folder' }}</h2>
 <form method="post">
   <div class="mb-3">
     <label class="form-label">Name</label>
-    <input class="form-control" name="name" required>
+    <input class="form-control" name="name" required value="{{ folder[1] if folder else '' }}">
   </div>
   <div class="mb-3">
     <label class="form-label">Pages</label>
-    <input type="number" class="form-control" name="pages" min="1" value="1" required>
+    <input type="number" class="form-control" name="pages" min="1" value="{{ folder[2] if folder else 1 }}" required>
   </div>
-  <button type="submit" class="btn btn-primary">Add</button>
+  <button type="submit" class="btn btn-primary">{{ 'Save' if folder else 'Add' }}</button>
 </form>
 {% endblock %}

--- a/templates/folders.html
+++ b/templates/folders.html
@@ -22,6 +22,7 @@
   <h4 class="mt-4">
     <button class="btn btn-sm btn-outline-secondary me-2 folder-toggle" data-target="folder-{{ f[0] }}">Hide</button>
     {{ f[1] }} ({{ '%02d'|format(f[0]) }})
+    <a href="{{ url_for('edit_folder_view', folder_id=f[0]) }}" class="btn btn-sm btn-outline-primary ms-2">Edit</a>
   </h4>
   <div id="folder-{{ f[0] }}">
   <table class="table table-sm table-striped">


### PR DESCRIPTION
## Summary
- allow renaming folders in `lager_manager`
- expose folder renaming in CLI and web interface
- update folder templates for editing
- document folder rename feature
- enable updating folder page count

## Testing
- `python -m py_compile cli.py lager_manager.py web.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6858606dc618832bb8b4e3dbf6bf7044