### PR TITLE
Clean up stray text in CLI and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,11 @@ require a login and sessions expire after 15 minutes of inactivity.
 The CLI can manage optional storage slots for physical binders.  Use option
 ``Ordner anlegen`` to create slots for a set (one page equals nine slots).  When
 adding a card without a storage code, the next free slot will be used if
-available.  If no slot exists the card is still stored without a loc
-d7qlx2-codex/erweiterte-ordnerbearbeitung-ohne-löschen
+available.  If no slot exists the card is still stored without a location.
 Existing folders can be edited via ``Ordner bearbeiten`` to change the name or
 page count without affecting the cards stored inside. Increasing the page count
-automatically creates additional storage slots.
-Existing folders can be renamed via ``Ordner umbenennen`` without affecting the
-cards stored inside.
-main
+automatically creates additional storage slots. Existing folders can also be
+renamed via ``Ordner umbenennen`` without affecting the cards stored inside.
 
 
 

--- a/cli.py
+++ b/cli.py
@@ -11,9 +11,7 @@ from TCGInventory.lager_manager import (
     delete_card,
     list_all_cards,
     add_folder,
-  d7qlx2-codex/erweiterte-ordnerbearbeitung-ohne-löschen
     edit_folder,
-  main
     rename_folder,
     export_inventory_csv,
 )
@@ -68,12 +66,9 @@ def show_menu():
     print(Fore.YELLOW + "3. Karte bearbeiten")
     print(Fore.YELLOW + "4. Karte löschen")
     print(Fore.YELLOW + "5. Ordner anlegen")
-    d7qlx2-codex/erweiterte-ordnerbearbeitung-ohne-löschen
     print(Fore.YELLOW + "6. Ordner bearbeiten")
-    
-    print(Fore.YELLOW + "6. Ordner umbenennen")
-    main
-    print(Fore.YELLOW + "7. Karten exportieren")
+    print(Fore.YELLOW + "7. Ordner umbenennen")
+    print(Fore.YELLOW + "8. Karten exportieren")
     print(Fore.YELLOW + "0. Beenden")
 
 
@@ -158,27 +153,23 @@ def run():
                     create_binder(folder_id, pages)
 
             elif choice == "6":
-d7qlx2-codex/erweiterte-ordnerbearbeitung-ohne-löschen
                 folder_id = _get_int("Ordner-ID zum Bearbeiten: ")
                 new_name = input("Neuer Name: ")
                 new_pages = _get_int("Neue Seitenanzahl: ")
                 edit_folder(folder_id, new_name, new_pages)
 
             elif choice == "7":
-                path = input("Dateiname für CSV-Export [inventory.csv]: ").strip() or "inventory.csv"
-                export_inventory_csv(path)
                 folder_id = _get_int("Ordner-ID zum Umbenennen: ")
                 new_name = input("Neuer Name: ")
                 rename_folder(folder_id, new_name)
 
-            elif choice == "7":
+            elif choice == "8":
                 folder = input("Ordnername für Export (leer = alle): ").strip() or None
                 path = (
                     input("Dateiname für CSV-Export [inventory.csv]: ").strip()
                     or "inventory.csv"
                 )
                 export_inventory_csv(path, folder)
-main
 
             elif choice == "0":
                 print(Fore.YELLOW + "👋 Programm beendet.")

--- a/docs/WEB_INTERFACE.md
+++ b/docs/WEB_INTERFACE.md
@@ -58,10 +58,7 @@ After submitting the form the cards appear in the **Upload Queue** where each en
 
 ## Managing folders
 
-d7qlx2-codex/erweiterte-ordnerbearbeitung-ohne-löschen
-Folders correspond to sets or binders. The **Folders** page lists all folders and the cards stored inside each one. When clicking **Add Folder** you can enter a name and the number of pages of the binder. Each page provides nine storage slots.  Cards can then be assigned to a folder and stored on a specific page and slot when adding or editing them. Existing folders can be edited using the **Edit** link next to each entry to change the name or page count. Increasing the number of pages automatically adds more storage slots.
+Folders correspond to sets or binders. The **Folders** page lists all folders and the cards stored inside each one. When clicking **Add Folder** you can enter a name and the number of pages of the binder. Each page provides nine storage slots. Cards can then be assigned to a folder and stored on a specific page and slot when adding or editing them. Existing folders can be edited using the **Edit** link next to each entry to change the name or page count. Increasing the number of pages automatically adds more storage slots. Existing folders can also be renamed using the **Rename** link.
 
-Folders correspond to sets or binders. The **Folders** page lists all folders and the cards stored inside each one. When clicking **Add Folder** you can enter a name and the number of pages of the binder. Each page provides nine storage slots.  Cards can then be assigned to a folder and stored on a specific page and slot when adding or editing them. Existing folders can be renamed using the **Edit** link next to each entry.
-main
 The overview also offers a small form to filter the listed cards by name, ID or storage code and to sort them by name, ID or storage.
 

--- a/lager_manager.py
+++ b/lager_manager.py
@@ -16,9 +16,7 @@ __all__ = [
     "delete_card",
     "get_next_free_slot",
     "add_folder",
-d7qlx2-codex/erweiterte-ordnerbearbeitung-ohne-löschen
     "edit_folder",
-main
     "rename_folder",
     "list_folders",
     "export_inventory_csv",
@@ -300,7 +298,6 @@ def list_folders():
 
 def rename_folder(folder_id: int, new_name: str) -> bool:
     """Rename a folder without touching its cards."""
-d7qlx2-codex/erweiterte-ordnerbearbeitung-ohne-löschen
     return edit_folder(folder_id, new_name)
 
 
@@ -324,16 +321,6 @@ def edit_folder(folder_id: int, new_name: str, pages: int | None = None) -> bool
             create_binder(folder_id, new_pages - current_pages)
         if cursor.rowcount:
             print(f"📁 Ordner {folder_id} aktualisiert.")
-    with sqlite3.connect(DB_FILE) as conn:
-        cursor = conn.cursor()
-        cursor.execute(
-            "UPDATE folders SET name = ? WHERE id = ?",
-            (new_name, folder_id),
-        )
-        conn.commit()
-        if cursor.rowcount:
-            print(f"📁 Ordner {folder_id} umbenannt in '{new_name}'.")
- main
             return True
         print(f"⚠️ Kein Ordner mit ID {folder_id} gefunden.")
         return False

--- a/templates/folder_form.html
+++ b/templates/folder_form.html
@@ -11,10 +11,7 @@
     <label class="form-label">Pages</label>
     <input type="number" class="form-control" name="pages" min="1" value="{{ folder[2] if folder else 1 }}" required>
   </div>
-d7qlx2-codex/erweiterte-ordnerbearbeitung-ohne-löschen
-
   {% endif %}
-main
   <button type="submit" class="btn btn-primary">{{ 'Save' if folder else 'Add' }}</button>
 </form>
 {% endblock %}

--- a/web.py
+++ b/web.py
@@ -21,9 +21,7 @@ from TCGInventory.lager_manager import (
     delete_card,
     add_storage_slot,
     add_folder,
-d7qlx2-codex/erweiterte-ordnerbearbeitung-ohne-löschen
     edit_folder,
-main
     rename_folder,
     create_binder,
     list_folders,
@@ -361,22 +359,16 @@ def add_folder_view():
 def edit_folder_view(folder_id: int):
     with sqlite3.connect(DB_FILE) as conn:
         c = conn.cursor()
-        d7qlx2-codex/erweiterte-ordnerbearbeitung-ohne-löschen
         c.execute("SELECT id, name, pages FROM folders WHERE id=?", (folder_id,))
-
         c.execute("SELECT id, name FROM folders WHERE id=?", (folder_id,))
-main
         folder = c.fetchone()
     if not folder:
         flash("Folder not found", "error")
         return redirect(url_for("list_folders_view"))
     if request.method == "POST":
-d7qlx2-codex/erweiterte-ordnerbearbeitung-ohne-löschen
         pages = int(request.form.get("pages", folder[2] or 0))
         edit_folder(folder_id, request.form["name"], pages)
-
         rename_folder(folder_id, request.form["name"])
-main
         flash("Folder updated")
         return redirect(url_for("list_folders_view"))
     return render_template("folder_form.html", folder=folder)


### PR DESCRIPTION
## Summary
- remove stray placeholder text and fix README wording
- clean up CLI menu and choices
- fix folder management docs
- repair folder form template
- tidy folder editing logic in the backend

## Testing
- `python -m py_compile *.py`
- `flake8 | head`

------
https://chatgpt.com/codex/tasks/task_e_68595e5fac00832b9c70ac0a14e379e4