### PR TITLE
Enable full folder management in web UI

### DIFF
--- a/docs/WEB_INTERFACE.md
+++ b/docs/WEB_INTERFACE.md
@@ -58,7 +58,7 @@ After submitting the form the cards appear in the **Upload Queue** where each en
 
 ## Managing folders
 
-Folders correspond to sets or binders. The **Folders** page lists all folders and the cards stored inside each one. When clicking **Add Folder** you can enter a name and the number of pages of the binder. Each page provides nine storage slots. Cards can then be assigned to a folder and stored on a specific page and slot when adding or editing them. Existing folders can be edited using the **Edit** link next to each entry to change the name or page count. Increasing the number of pages automatically adds more storage slots. Existing folders can also be renamed using the **Rename** link.
+Folders correspond to sets or binders. The **Folders** page lists all folders and the cards stored inside each one. When clicking **Add Folder** you can enter a name and the number of pages of the binder. Each page provides nine storage slots. Cards can then be assigned to a folder and stored on a specific page and slot when adding or editing them. Existing folders can be edited using the **Edit** link next to each entry to change the name or page count. Increasing the number of pages automatically adds more storage slots. Folders can also be removed via the **Delete** link.
 
 The overview also offers a small form to filter the listed cards by name, ID or storage code and to sort them by name, ID or storage.
 

--- a/lager_manager.py
+++ b/lager_manager.py
@@ -18,6 +18,7 @@ __all__ = [
     "add_folder",
     "edit_folder",
     "rename_folder",
+    "delete_folder",
     "list_folders",
     "export_inventory_csv",
 ]
@@ -324,4 +325,23 @@ def edit_folder(folder_id: int, new_name: str, pages: int | None = None) -> bool
             return True
         print(f"⚠️ Kein Ordner mit ID {folder_id} gefunden.")
         return False
+
+
+def delete_folder(folder_id: int) -> bool:
+    """Delete a folder and clear related storage slots."""
+    prefix = f"O{int(folder_id):02d}-"
+    with sqlite3.connect(DB_FILE) as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            "UPDATE cards SET folder_id = NULL, storage_code = NULL WHERE folder_id = ?",
+            (folder_id,),
+        )
+        cursor.execute("DELETE FROM storage_slots WHERE code LIKE ?", (f"{prefix}%",))
+        cursor.execute("DELETE FROM folders WHERE id = ?", (folder_id,))
+        conn.commit()
+        if cursor.rowcount:
+            print(f"🗑️ Ordner {folder_id} gelöscht.")
+            return True
+    print(f"⚠️ Kein Ordner mit ID {folder_id} gefunden.")
+    return False
 

--- a/templates/folder_form.html
+++ b/templates/folder_form.html
@@ -6,12 +6,10 @@
     <label class="form-label">Name</label>
     <input class="form-control" name="name" required value="{{ folder[1] if folder else '' }}">
   </div>
-  {% if not folder %}
   <div class="mb-3">
     <label class="form-label">Pages</label>
     <input type="number" class="form-control" name="pages" min="1" value="{{ folder[2] if folder else 1 }}" required>
   </div>
-  {% endif %}
   <button type="submit" class="btn btn-primary">{{ 'Save' if folder else 'Add' }}</button>
 </form>
 {% endblock %}

--- a/templates/folders.html
+++ b/templates/folders.html
@@ -22,8 +22,9 @@
   <h4 class="mt-4">
     <button class="btn btn-sm btn-outline-secondary me-2 folder-toggle" data-target="folder-{{ f[0] }}">Hide</button>
     <a href="{{ url_for('export_cards', folder=f[0]) }}" class="btn btn-sm btn-outline-secondary me-2">Export CSV</a>
-    {{ f[1] }} ({{ '%02d'|format(f[0]) }})
+    {{ f[1] }} ({{ '%02d'|format(f[0]) }}) - {{ f[2] }} pages
     <a href="{{ url_for('edit_folder_view', folder_id=f[0]) }}" class="btn btn-sm btn-outline-primary ms-2">Edit</a>
+    <a href="{{ url_for('delete_folder_view', folder_id=f[0]) }}" class="btn btn-sm btn-outline-danger ms-2">Delete</a>
   </h4>
   <div id="folder-{{ f[0] }}">
   <table class="table table-sm table-striped">

--- a/web.py
+++ b/web.py
@@ -22,7 +22,7 @@ from TCGInventory.lager_manager import (
     add_storage_slot,
     add_folder,
     edit_folder,
-    rename_folder,
+    delete_folder,
     create_binder,
     list_folders,
 )
@@ -304,6 +304,14 @@ def delete_card_route(card_id: int):
     return redirect(url_for("list_cards"))
 
 
+@app.route("/folders/delete/<int:folder_id>")
+@login_required
+def delete_folder_view(folder_id: int):
+    delete_folder(folder_id)
+    flash("Folder deleted")
+    return redirect(url_for("list_folders_view"))
+
+
 @app.route("/folders")
 @login_required
 def list_folders_view():
@@ -361,7 +369,6 @@ def edit_folder_view(folder_id: int):
     with sqlite3.connect(DB_FILE) as conn:
         c = conn.cursor()
         c.execute("SELECT id, name, pages FROM folders WHERE id=?", (folder_id,))
-        c.execute("SELECT id, name FROM folders WHERE id=?", (folder_id,))
         folder = c.fetchone()
     if not folder:
         flash("Folder not found", "error")
@@ -369,7 +376,6 @@ def edit_folder_view(folder_id: int):
     if request.method == "POST":
         pages = int(request.form.get("pages", folder[2] or 0))
         edit_folder(folder_id, request.form["name"], pages)
-        rename_folder(folder_id, request.form["name"])
         flash("Folder updated")
         return redirect(url_for("list_folders_view"))
     return render_template("folder_form.html", folder=folder)


### PR DESCRIPTION
## Summary
- fix folder edit view by loading page count correctly
- allow editing page count in the folder form
- add ability to delete folders and remove their storage slots
- display page count and delete link on folder overview
- document folder deletion in the web interface docs

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68596ef0f010832b81de32b7d31ea677