### PR TITLE
Enable collector number selection

### DIFF
--- a/docs/WEB_INTERFACE.md
+++ b/docs/WEB_INTERFACE.md
@@ -46,7 +46,8 @@ card lookups are then served from the local SQLite database without
 internet access.  If no local data is found the Scryfall API is used as
 fallback.
 Selecting a suggested entry automatically fills language and ID fields. If
-multiple versions exist a second dropdown lets you choose the exact variant.
+multiple versions exist a second dropdown lets you choose the exact variant,
+including the collector number.
 
 To change an existing card, click **Edit** next to the card and modify the fields in the form.
 

--- a/templates/card_form.html
+++ b/templates/card_form.html
@@ -146,7 +146,10 @@ document.addEventListener('DOMContentLoaded', function() {
           list.forEach(info => {
             const opt = document.createElement('option');
             opt.value = JSON.stringify(info);
-            opt.textContent = `${info.set_code} (${info.language})`;
+            let label = `${info.set_code}`;
+            if (info.collector_number) label += ` #${info.collector_number}`;
+            label += ` (${info.language})`;
+            opt.textContent = label;
             variantSelect.appendChild(opt);
           });
           variantSelect.classList.remove('d-none');


### PR DESCRIPTION
## Summary
- show collector numbers inside the variant dropdown
- document that the variant selector includes collector numbers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d55d09ed4832bbf3d68f0aaff40dc