### PR TITLE
Add folder ID editing and reuse freed numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,11 @@ adding a card without a storage code, the next free slot will be used if
 available. If no slot exists the card is still stored without a location code.
 Existing folders can be edited via ``Ordner bearbeiten`` to change the name or
 page count without affecting the cards stored inside. Increasing the page count
-automatically creates additional storage slots. Existing folders can also be
-renamed via ``Ordner umbenennen`` without affecting the cards stored inside.
+automatically creates additional storage slots. The folder ID can also be
+changed there as long as the new number is not already used. Newly created
+folders always receive the lowest free ID so numbering stays compact. Existing
+folders can also be renamed via ``Ordner umbenennen`` without affecting the
+cards stored inside.
 
 
 

--- a/cli.py
+++ b/cli.py
@@ -159,7 +159,9 @@ def run():
                 folder_id = _get_int("Ordner-ID zum Bearbeiten: ")
                 new_name = input("Neuer Name: ")
                 new_pages = _get_int("Neue Seitenanzahl: ")
-                edit_folder(folder_id, new_name, new_pages)
+                new_id_input = input("Neue Ordner-ID (leer = unverändert): ").strip()
+                new_id = int(new_id_input) if new_id_input.isdigit() else None
+                edit_folder(folder_id, new_name, new_pages, new_id)
 
             elif choice == "7":
                 folder_id = _get_int("Ordner-ID zum Umbenennen: ")

--- a/docs/WEB_INTERFACE.md
+++ b/docs/WEB_INTERFACE.md
@@ -60,6 +60,7 @@ A small checkbox lets you mark whether a card is foil before uploading.
 ## Managing folders
 
 Folders correspond to sets or binders. The **Folders** page lists all folders and the cards stored inside each one. When clicking **Add Folder** you can enter a name and the number of pages of the binder. Each page provides nine storage slots. Cards can then be assigned to a folder and stored on a specific page and slot when adding or editing them. Existing folders can be edited using the **Edit** link next to each entry to change the name or page count. Increasing the number of pages automatically adds more storage slots. Folders can be removed from within the edit view using the **Delete** button.
+The folder ID can also be changed in the edit view if needed. Newly created folders automatically receive the lowest free ID so the numbering stays compact.
 
 The overview also offers a small form to filter the listed cards by name, ID or storage code and to sort them by name, ID or storage.
 

--- a/templates/folder_form.html
+++ b/templates/folder_form.html
@@ -6,6 +6,12 @@
     <label class="form-label">Name</label>
     <input class="form-control" name="name" required value="{{ folder[1] if folder else '' }}">
   </div>
+  {% if folder %}
+  <div class="mb-3">
+    <label class="form-label">ID</label>
+    <input type="number" class="form-control" name="id" min="1" value="{{ folder[0] }}">
+  </div>
+  {% endif %}
   <div class="mb-3">
     <label class="form-label">Pages</label>
     <input type="number" class="form-control" name="pages" min="1" value="{{ folder[2] if folder else 1 }}" required>

--- a/web.py
+++ b/web.py
@@ -377,7 +377,9 @@ def edit_folder_view(folder_id: int):
         return redirect(url_for("list_folders_view"))
     if request.method == "POST":
         pages = int(request.form.get("pages", folder[2] or 0))
-        edit_folder(folder_id, request.form["name"], pages)
+        new_id_val = request.form.get("id")
+        new_id = int(new_id_val) if new_id_val and new_id_val.isdigit() else None
+        edit_folder(folder_id, request.form["name"], pages, new_id)
         flash("Folder updated")
         return redirect(url_for("list_folders_view"))
     return render_template("folder_form.html", folder=folder)


### PR DESCRIPTION
## Summary
- assign the lowest free folder ID when creating a new folder
- allow editing of folder IDs via CLI and web interface
- update README and docs about folder management

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m TCGInventory.setup_db`


------
https://chatgpt.com/codex/tasks/task_e_685d5667faec832bb4ee6683e5fc661c