### PR TITLE
Fix folder deletion to also remove cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Existing folders can be edited via ``Ordner bearbeiten`` to change the name or
 page count without affecting the cards stored inside. Increasing the page count
 automatically creates additional storage slots. Existing folders can also be
 renamed via ``Ordner umbenennen`` without affecting the cards stored inside.
+Deleting a folder will remove all cards stored inside and free their slots.
 
 
 

--- a/lager_manager.py
+++ b/lager_manager.py
@@ -331,20 +331,28 @@ def edit_folder(folder_id: int, new_name: str, pages: int | None = None) -> bool
 
 
 def delete_folder(folder_id: int) -> bool:
-    """Delete a folder and clear related storage slots."""
+    """Delete a folder along with its cards and storage slots."""
     prefix = f"O{int(folder_id):02d}-"
+
+    # Collect card IDs inside the folder
     with sqlite3.connect(DB_FILE) as conn:
         cursor = conn.cursor()
-        cursor.execute(
-            "UPDATE cards SET folder_id = NULL, storage_code = NULL WHERE folder_id = ?",
-            (folder_id,),
-        )
+        cursor.execute("SELECT id FROM cards WHERE folder_id = ?", (folder_id,))
+        card_ids = [row[0] for row in cursor.fetchall()]
+
+    # Remove cards and free their slots
+    for card_id in card_ids:
+        delete_card(card_id)
+
+    with sqlite3.connect(DB_FILE) as conn:
+        cursor = conn.cursor()
         cursor.execute("DELETE FROM storage_slots WHERE code LIKE ?", (f"{prefix}%",))
         cursor.execute("DELETE FROM folders WHERE id = ?", (folder_id,))
         conn.commit()
         if cursor.rowcount:
             print(f"🗑️ Ordner {folder_id} gelöscht.")
             return True
+
     print(f"⚠️ Kein Ordner mit ID {folder_id} gefunden.")
     return False
 


### PR DESCRIPTION
## Summary
- deleting a folder now deletes all cards inside and frees their storage slots
- document this new behaviour in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d581004b4832bae245cc8d6865510