### PR TITLE
Add foil indicator

### DIFF
--- a/docs/WEB_INTERFACE.md
+++ b/docs/WEB_INTERFACE.md
@@ -50,6 +50,7 @@ multiple versions exist a second dropdown lets you choose the exact variant,
 including the collector number.
 
 To change an existing card, click **Edit** next to the card and modify the fields in the form.
+Use the *Foil* checkbox to mark shiny versions. Foil cards are shown with a **★** symbol next to their name in the card and folder overviews.
 
 ## Bulk adding cards
 

--- a/templates/cards.html
+++ b/templates/cards.html
@@ -14,7 +14,7 @@
 <tr>
 <td>{{ c[0] }}</td>
 <td>{% if c[10] %}<img src="{{ c[10] }}" style="max-height:80px;" class="img-thumbnail clickable-image" data-bs-toggle="modal" data-bs-target="#imgModal" data-img="{{ c[10] }}">{% endif %}</td>
-<td>{{ c[1] }}</td>
+<td>{{ c[1] }}{% if c[11] %} <span title="Foil">★</span>{% endif %}</td>
 <td>{{ c[2] }}</td>
 <td>{{ c[3] }}</td>
 <td>{{ c[4] }}</td>

--- a/templates/folders.html
+++ b/templates/folders.html
@@ -31,7 +31,7 @@
     {% for c in folder_cards.get(f[0], []) %}
     <tr>
       <td>{{ c[0] }}</td>
-      <td>{{ c[1] }}</td>
+      <td>{{ c[1] }}{% if c[5] %} <span title="Foil">★</span>{% endif %}</td>
       <td>{{ c[2] }}</td>
       <td>{{ c[3] }}</td>
       <td>{{ c[4] }}</td>

--- a/web.py
+++ b/web.py
@@ -329,7 +329,7 @@ def list_folders_view():
         c = conn.cursor()
         for fid, _, _ in folders:
             query = (
-                "SELECT id, name, set_code, quantity, storage_code FROM cards "
+                "SELECT id, name, set_code, quantity, storage_code, foil FROM cards "
                 "WHERE folder_id=?"
             )
             params = [fid]


### PR DESCRIPTION
## Summary
- show a ★ next to foil cards in card and folder lists
- include foil column when querying folder contents
- document foil checkbox and symbol

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python web.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685d588709cc832ba1c4ecb9a1f3d544