### PR TITLE
Add search to upload queue

### DIFF
--- a/templates/upload_queue.html
+++ b/templates/upload_queue.html
@@ -1,6 +1,12 @@
 {% extends "base.html" %}
 {% block content %}
 <h2 class="mb-4">Upload Queue</h2>
+<form method="get" class="mb-3">
+  <div class="input-group">
+    <input class="form-control" type="text" name="q" placeholder="Search" value="{{ search }}">
+    <button class="btn btn-outline-secondary" type="submit">Search</button>
+  </div>
+</form>
 {% if queue %}
 <table class="table">
   <thead>

--- a/web.py
+++ b/web.py
@@ -558,7 +558,11 @@ def bulk_add_view():
 @login_required
 def upload_queue_view():
     """Display queued cards from the bulk upload."""
-    return render_template("upload_queue.html", queue=UPLOAD_QUEUE)
+    search = request.args.get("q", "").strip()
+    queue = UPLOAD_QUEUE
+    if search:
+        queue = [c for c in UPLOAD_QUEUE if search.lower() in c.get("name", "").lower()]
+    return render_template("upload_queue.html", queue=queue, search=search)
 
 
 @app.route("/cards/upload_queue/foil/<int:index>", methods=["POST"])


### PR DESCRIPTION
## Summary
- enable searching the upload queue
- expose search box on the Upload Queue page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68600ebcb508832b83f7d99a2037080c