### PR TITLE
Add clear upload queue feature

### DIFF
--- a/templates/upload_queue.html
+++ b/templates/upload_queue.html
@@ -36,7 +36,8 @@
     {% endfor %}
   </tbody>
 </table>
-<a class="btn btn-primary" href="{{ url_for('upload_all_route') }}">Add All</a>
+<a class="btn btn-primary me-2" href="{{ url_for('upload_all_route') }}">Add All</a>
+<a class="btn btn-outline-danger" href="{{ url_for('clear_upload_queue') }}">Clear Queue</a>
 {% else %}
 <p>No cards in queue.</p>
 {% endif %}

--- a/tests/test_upload_queue.py
+++ b/tests/test_upload_queue.py
@@ -1,0 +1,26 @@
+import sys
+import os
+import types
+
+# Stub out heavy dependencies used by card_scanner
+sys.modules.setdefault('cv2', types.SimpleNamespace())
+pyzbar = types.ModuleType('pyzbar')
+pyzbar.pyzbar = types.SimpleNamespace(decode=lambda *a, **k: [])
+sys.modules.setdefault('pyzbar', pyzbar)
+sys.modules.setdefault('pyzbar.pyzbar', pyzbar.pyzbar)
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from TCGInventory.web import app, UPLOAD_QUEUE
+
+
+def test_clear_upload_queue():
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        with client.session_transaction() as sess:
+            sess['user'] = 'test'
+        UPLOAD_QUEUE.extend([{'name': 'a'}, {'name': 'b'}])
+        assert len(UPLOAD_QUEUE) == 2
+        resp = client.get('/cards/upload_queue/clear')
+        assert resp.status_code == 302
+        assert len(UPLOAD_QUEUE) == 0

--- a/web.py
+++ b/web.py
@@ -690,6 +690,15 @@ def upload_all_route():
     return redirect(url_for("list_cards"))
 
 
+@app.route("/cards/upload_queue/clear")
+@login_required
+def clear_upload_queue():
+    """Remove all cards from the upload queue."""
+    UPLOAD_QUEUE.clear()
+    flash("Upload queue cleared")
+    return redirect(url_for("upload_queue_view"))
+
+
 @app.route("/update")
 @login_required
 def update_view():


### PR DESCRIPTION
## Summary
- add route to clear all cards from the upload queue
- add button on queue page
- test clearing the upload queue

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68600edf8d40832bb3afb5084a22c1f3