### PR TITLE
Use 0.0.0.0 as default Flask host

### DIFF
--- a/web.py
+++ b/web.py
@@ -723,6 +723,6 @@ def update_view():
 
 if __name__ == "__main__":
     init_db()
-    host = os.environ.get("FLASK_RUN_HOST", "127.0.0.1")
+    host = os.environ.get("FLASK_RUN_HOST", "0.0.0.0")
     port = int(os.environ.get("FLASK_RUN_PORT", 5000))
     app.run(host=host, port=port, debug=True)


### PR DESCRIPTION
## Summary
- modify web.py so the default `FLASK_RUN_HOST` is `0.0.0.0` instead of `127.0.0.1`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68616f605988832ba1fdf55de6b4e24e