### PR TITLE
Fix collector number handling in CSV uploads

### DIFF
--- a/tests/test_bulk_upload.py
+++ b/tests/test_bulk_upload.py
@@ -1,0 +1,38 @@
+import os
+import sys
+import types
+
+# Stub out heavy dependencies used by card_scanner
+sys.modules.setdefault('cv2', types.SimpleNamespace())
+pyzbar = types.ModuleType('pyzbar')
+pyzbar.pyzbar = types.SimpleNamespace(decode=lambda *a, **k: [])
+sys.modules.setdefault('pyzbar', pyzbar)
+sys.modules.setdefault('pyzbar.pyzbar', pyzbar.pyzbar)
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+
+from TCGInventory import web
+from TCGInventory.web import _process_bulk_upload, UPLOAD_QUEUE
+
+
+def test_bulk_upload_preserves_collector_number(monkeypatch):
+    """CSV uploads should keep the provided collector number if no variant is found."""
+    monkeypatch.setattr(web, "fetch_card_info_by_name", lambda name: {
+        "name": name,
+        "set_code": "ABC",
+        "collector_number": "007",
+    })
+    monkeypatch.setattr(web, "find_variant", lambda *a, **k: None)
+    monkeypatch.setattr(web, "list_folders", lambda: [])
+
+    UPLOAD_QUEUE.clear()
+    web.BULK_PROGRESS = 0
+    web.BULK_DONE = False
+    web.BULK_MESSAGE = None
+    form_data = {"cards": "", "folder_id": None}
+    csv_content = "Card Name,Set Code,Card Number\nSample Card,ABC,123\n"
+    _process_bulk_upload(form_data, None, csv_content.encode())
+
+    assert len(UPLOAD_QUEUE) == 1
+    assert UPLOAD_QUEUE[0]["collector_number"] == "123"
+    UPLOAD_QUEUE.clear()

--- a/tests/test_find_variant.py
+++ b/tests/test_find_variant.py
@@ -11,7 +11,7 @@ pyzbar.pyzbar = types.SimpleNamespace(decode=lambda *a, **k: [])
 sys.modules.setdefault('pyzbar', pyzbar)
 sys.modules.setdefault('pyzbar.pyzbar', pyzbar.pyzbar)
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
 
 import TCGInventory.card_scanner as cs  # noqa: E402
 

--- a/tests/test_upload_queue.py
+++ b/tests/test_upload_queue.py
@@ -9,7 +9,7 @@ pyzbar.pyzbar = types.SimpleNamespace(decode=lambda *a, **k: [])
 sys.modules.setdefault('pyzbar', pyzbar)
 sys.modules.setdefault('pyzbar.pyzbar', pyzbar.pyzbar)
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
 
 from TCGInventory import web
 from TCGInventory.web import app, UPLOAD_QUEUE

--- a/web.py
+++ b/web.py
@@ -338,8 +338,8 @@ def _process_bulk_upload(form_data: dict, json_bytes: bytes | None, csv_bytes: b
                     info = variant
                     card_no = variant.get("collector_number", card_no)
                     set_row = variant.get("set_code", set_row)
-                elif info and card_no and card_no != info.get("collector_number", ""):
-                    card_no = info.get("collector_number", card_no)
+                elif info and not card_no:
+                    card_no = info.get("collector_number", "")
                 if not info:
                     info = {}
                 UPLOAD_QUEUE.append(
@@ -633,8 +633,8 @@ def bulk_add_view():
                             info = variant
                             card_no = variant.get("collector_number", card_no)
                             set_row = variant.get("set_code", set_row)
-                        elif info and card_no and card_no != info.get("collector_number", ""):
-                            card_no = info.get("collector_number", card_no)
+                        elif info and not card_no:
+                            card_no = info.get("collector_number", "")
                         if not info:
                             info = {}
                         UPLOAD_QUEUE.append(


### PR DESCRIPTION
## Summary
- keep provided collector number if variant lookup fails
- adjust path handling in tests
- add regression test for CSV bulk upload

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68625580d3b4832bb839eedd11c1f11d