### PR TITLE
Improve bulk upload progress feedback

### DIFF
--- a/templates/bulk_add.html
+++ b/templates/bulk_add.html
@@ -25,7 +25,7 @@
   </div>
   <button type="submit" class="btn btn-primary">Add</button>
   <div class="progress mt-3" style="display:none;" id="upload-progress">
-    <div class="progress-bar" role="progressbar" style="width:0%"></div>
+    <div class="progress-bar progress-bar-striped progress-bar-animated bg-info" role="progressbar" style="width:0%">0%</div>
   </div>
   <div class="mt-2 text-muted" id="upload-status" style="display:none;">Uploading...</div>
 </form>
@@ -40,21 +40,26 @@ document.addEventListener('DOMContentLoaded', function () {
     e.preventDefault();
     const xhr = new XMLHttpRequest();
     xhr.open('POST', form.action);
-    xhr.responseType = 'document';
+    xhr.responseType = 'text';
 
     xhr.upload.addEventListener('progress', function (ev) {
       if (ev.lengthComputable) {
         const percent = (ev.loaded / ev.total) * 100;
         bar.style.width = percent + '%';
+
+        bar.textContent = Math.round(percent) + '%';
       }
     });
 
     xhr.addEventListener('load', function () {
-      window.location.href = xhr.responseURL;
+      document.open();
+      document.write(xhr.responseText);
+      document.close();
     });
 
     progress.style.display = 'block';
     status.style.display = 'block';
+    status.textContent = 'Uploading...';
     bar.style.width = '0%';
 
     const formData = new FormData(form);

--- a/templates/bulk_add_progress.html
+++ b/templates/bulk_add_progress.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+{% block content %}
+<h2 class="mb-4">Processing Upload</h2>
+<div class="progress mt-3">
+  <div class="progress-bar progress-bar-striped progress-bar-animated bg-info" role="progressbar" style="width:0%">0%</div>
+</div>
+<div class="mt-2 text-muted" id="upload-status">Processing...</div>
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+  const bar = document.querySelector('.progress-bar');
+  function poll() {
+    fetch('{{ url_for('bulk_add_progress') }}')
+      .then(r => r.json())
+      .then(data => {
+        bar.style.width = data.percent + '%';
+        bar.textContent = data.percent + '%';
+        if (data.done) {
+          window.location.href = '{{ url_for('upload_queue_view') }}';
+        } else {
+          setTimeout(poll, 1000);
+        }
+      });
+  }
+  poll();
+});
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- process bulk upload files in background thread
- track progress percentage during processing
- add endpoint and page to show processing progress
- show server response page when upload completes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68624745b3c8832b9a2412ed642b0405