### PR TITLE
Fix card number overrides on bulk upload

### DIFF
--- a/tests/test_bulk_upload.py
+++ b/tests/test_bulk_upload.py
@@ -36,3 +36,35 @@ def test_bulk_upload_preserves_collector_number(monkeypatch):
     assert len(UPLOAD_QUEUE) == 1
     assert UPLOAD_QUEUE[0]["collector_number"] == "123"
     UPLOAD_QUEUE.clear()
+
+
+def test_bulk_upload_keeps_number_if_variant_found(monkeypatch):
+    """Provided collector numbers should not be overwritten by variant data."""
+    monkeypatch.setattr(web, "fetch_card_info_by_name", lambda name: {
+        "name": name,
+        "set_code": "ABC",
+        "collector_number": "0123",
+    })
+
+    monkeypatch.setattr(
+        web,
+        "find_variant",
+        lambda *a, **k: {
+            "name": "Sample Card",
+            "set_code": "ABC",
+            "collector_number": "0123",
+        },
+    )
+    monkeypatch.setattr(web, "list_folders", lambda: [])
+
+    UPLOAD_QUEUE.clear()
+    web.BULK_PROGRESS = 0
+    web.BULK_DONE = False
+    web.BULK_MESSAGE = None
+    form_data = {"cards": "", "folder_id": None}
+    csv_content = "Card Name,Set Code,Card Number\nSample Card,ABC,123\n"
+    _process_bulk_upload(form_data, None, csv_content.encode())
+
+    assert len(UPLOAD_QUEUE) == 1
+    assert UPLOAD_QUEUE[0]["collector_number"] == "123"
+    UPLOAD_QUEUE.clear()

--- a/web.py
+++ b/web.py
@@ -336,11 +336,9 @@ def _process_bulk_upload(form_data: dict, json_bytes: bytes | None, csv_bytes: b
                     variant = find_variant(name, set_row or info.get("set_code", ""), card_no)
                 if variant:
                     info = variant
-                    card_no = variant.get("collector_number", card_no)
+                    if not card_no:
+                        card_no = variant.get("collector_number", card_no)
                     set_row = variant.get("set_code", set_row)
-
-                elif info and card_no and card_no != info.get("collector_number", ""):
-                    card_no = info.get("collector_number", card_no)
 
                 elif info and not card_no:
                     card_no = info.get("collector_number", "")
@@ -638,7 +636,8 @@ def bulk_add_view():
                             )
                         if variant:
                             info = variant
-                            card_no = variant.get("collector_number", card_no)
+                            if not card_no:
+                                card_no = variant.get("collector_number", card_no)
                             set_row = variant.get("set_code", set_row)
                         elif info and not card_no:
                             card_no = info.get("collector_number", "")


### PR DESCRIPTION
## Summary
- keep provided collector numbers when a variant is found
- add regression test for collector number preservation
- ensure progress flags reset in new variant test

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686283370f2c832b80c98242f19fc201