### PR TITLE
Implement sell button for cards

### DIFF
--- a/templates/cards.html
+++ b/templates/cards.html
@@ -11,7 +11,7 @@
 <table class="table table-striped">
 <tr><th>Number</th><th>Image</th><th>Name</th><th>Set</th><th>Lang</th><th>Condition</th><th>Price</th><th>Qty</th><th>Storage</th><th>Folder</th><th>Status</th><th>Actions</th></tr>
 {% for c in cards %}
-<tr>
+<tr data-card-id="{{ c[0] }}">
 <td>{{ c[12] }}</td>
 <td>{% if c[10] %}<img src="{{ c[10] }}" style="max-height:80px;" class="img-thumbnail clickable-image" data-bs-toggle="modal" data-bs-target="#imgModal" data-img="{{ c[10] }}">{% endif %}</td>
 <td>{{ c[1] }}{% if c[11] %} <span title="Foil">★</span>{% endif %}</td>
@@ -19,11 +19,14 @@
 <td>{{ c[3] }}</td>
 <td>{{ c[4] }}</td>
 <td>{{ c[5] }}</td>
-<td>{{ c[6] }}</td>
+<td class="qty-cell">{{ c[6] }}</td>
 <td>{{ c[7] }}</td>
 <td>{{ c[8] }}</td>
 <td>{{ c[9] }}</td>
-<td><a class="btn btn-sm btn-outline-primary" href="{{ url_for('edit_card_view', card_id=c[0]) }}">Edit</a> <a class="btn btn-sm btn-outline-danger" href="{{ url_for('delete_card_route', card_id=c[0]) }}">Delete</a></td>
+<td>
+  <a class="btn btn-sm btn-outline-primary" href="{{ url_for('edit_card_view', card_id=c[0]) }}">Edit</a>
+  <button type="button" class="btn btn-sm btn-outline-danger sell-btn" data-id="{{ c[0] }}">Verkauft</button>
+</td>
 </tr>
 {% endfor %}
 </table>
@@ -84,6 +87,25 @@ document.addEventListener('DOMContentLoaded', function() {
         modal.show();
       }
     }
+  });
+
+  document.querySelectorAll('.sell-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const id = btn.getAttribute('data-id');
+      fetch(`/cards/${id}/sell`, { method: 'POST' })
+        .then(r => r.json())
+        .then(data => {
+          if (data.removed) {
+            window.location.reload();
+          } else {
+            const row = btn.closest('tr');
+            if (row) {
+              const cell = row.querySelector('.qty-cell');
+              if (cell) cell.textContent = data.quantity;
+            }
+          }
+        });
+    });
   });
 });
 </script>

--- a/tests/test_sell_card.py
+++ b/tests/test_sell_card.py
@@ -1,0 +1,49 @@
+import os
+import sys
+import sqlite3
+import types
+
+# Stub heavy dependencies
+sys.modules.setdefault('cv2', types.SimpleNamespace())
+pyzbar = types.ModuleType('pyzbar')
+pyzbar.pyzbar = types.SimpleNamespace(decode=lambda *a, **k: [])
+sys.modules.setdefault('pyzbar', pyzbar)
+sys.modules.setdefault('pyzbar.pyzbar', pyzbar.pyzbar)
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+
+from TCGInventory import web
+from TCGInventory.setup_db import initialize_database
+from TCGInventory.lager_manager import add_card
+
+
+def test_sell_route(tmp_path, monkeypatch):
+    db = tmp_path / "db.sqlite"
+    monkeypatch.setattr(web, "DB_FILE", str(db))
+    monkeypatch.setattr(sys.modules['TCGInventory'], 'DB_FILE', str(db))
+    monkeypatch.setattr(sys.modules['TCGInventory.setup_db'], 'DB_FILE', str(db))
+    monkeypatch.setattr(sys.modules['TCGInventory.lager_manager'], 'DB_FILE', str(db))
+    initialize_database()
+
+    add_card("Sample", "SET", "en", "", 0.0, quantity=2)
+
+    with sqlite3.connect(str(db)) as conn:
+        card_id = conn.execute("SELECT id FROM cards").fetchone()[0]
+
+    app = web.app
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        with client.session_transaction() as sess:
+            sess['user'] = 'test'
+        resp = client.post(f"/cards/{card_id}/sell")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["quantity"] == 1 and not data["removed"]
+
+        resp = client.post(f"/cards/{card_id}/sell")
+        data = resp.get_json()
+        assert data["removed"]
+
+    with sqlite3.connect(str(db)) as conn:
+        count = conn.execute("SELECT COUNT(*) FROM cards").fetchone()[0]
+    assert count == 0

--- a/web.py
+++ b/web.py
@@ -489,6 +489,22 @@ def delete_card_route(card_id: int):
     return redirect(url_for("list_cards"))
 
 
+@app.route("/cards/<int:card_id>/sell", methods=["POST"])
+@login_required
+def sell_card_route(card_id: int):
+    """Decrease card quantity by one or delete if none remain."""
+    card = get_card(card_id)
+    if not card:
+        return jsonify({"error": "not found"}), 404
+    qty = card[6] or 0
+    if qty > 1:
+        update_card(card_id, quantity=qty - 1)
+        return jsonify({"quantity": qty - 1, "removed": False})
+    delete_card(card_id)
+    flash("Card sold")
+    return jsonify({"quantity": 0, "removed": True})
+
+
 @app.route("/folders/delete/<int:folder_id>")
 @login_required
 def delete_folder_view(folder_id: int):


### PR DESCRIPTION
## Summary
- add `/cards/<id>/sell` endpoint to decrement quantity or delete card
- replace delete action with a "Verkauft" button
- update quantity on the page via JavaScript without reload unless quantity hits zero
- test new selling logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686feae6c7d4832b9823e12ce4a52ca0